### PR TITLE
Add config file support for DB credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,19 @@ GNU General Public License for more details. You should have received a copy of 
 Public License along with this program; if not, write to the Free Software Foundation, Inc., 59
 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
+
+Configuration
+-------------
+scastd reads database settings from a simple configuration file at
+startup. The file contains lines of the form `key value` and supports
+`#` comments. By default the daemon looks for `scastd.conf` in the
+current directory, but an alternate path may be supplied as the first
+command line argument.
+
+Example `scastd.conf`:
+
+```
+# database credentials
+username root
+password secret
+```

--- a/scastd.conf
+++ b/scastd.conf
@@ -1,0 +1,4 @@
+# Sample scastd configuration
+# Lines starting with # are comments
+username root
+password secret

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,0 +1,36 @@
+#include "Config.h"
+#include <fstream>
+#include <sstream>
+
+bool Config::Load(const std::string &path) {
+    std::ifstream in(path.c_str());
+    if (!in) {
+        return false;
+    }
+    std::string line;
+    while (std::getline(in, line)) {
+        std::size_t pos = line.find('#');
+        if (pos != std::string::npos) {
+            line = line.substr(0, pos);
+        }
+        std::istringstream iss(line);
+        std::string key;
+        if (!(iss >> key)) {
+            continue;
+        }
+        std::string value;
+        if (!(iss >> value)) {
+            value.clear();
+        }
+        values[key] = value;
+    }
+    return true;
+}
+
+std::string Config::Get(const std::string &key, const std::string &def) const {
+    std::map<std::string, std::string>::const_iterator it = values.find(key);
+    if (it != values.end()) {
+        return it->second;
+    }
+    return def;
+}

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,0 +1,15 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <string>
+#include <map>
+
+class Config {
+public:
+    bool Load(const std::string &path);
+    std::string Get(const std::string &key, const std::string &def = "") const;
+private:
+    std::map<std::string, std::string> values;
+};
+
+#endif // CONFIG_H

--- a/src/DB.cpp
+++ b/src/DB.cpp
@@ -38,63 +38,59 @@ double  DBGetCurrentTime() {
         struct timeval  tv;
         gettimeofday(&tv, NULL);
         thetime = (double)tv.tv_sec + (double)((double)tv.tv_usec / (double)1000000);
-   
+
         return thetime;
 }
 
 DB::DB() {
-	pResult = 0;
-	sqlTimings = 0;
-	memset(tempQuery, '\000', sizeof(tempQuery));
+        pResult = 0;
+        sqlTimings = 0;
+        memset(tempQuery, '\000', sizeof(tempQuery));
 }
 DB::~DB() {
-	if (pResult) {
-		mysql_free_result(pResult);
-	}
+        if (pResult) {
+                mysql_free_result(pResult);
+        }
 }
-int DB::Connect() {
-	char	*username;
-	char	*password;
-	char	u[255] = "";
-	char	p[255] = "";
+int DB::Connect(const char *username, const char *password) {
+        char    u[255] = "";
+        char    p[255] = "";
         mysql_init(&mySQL);
 
 
         mysql_options(&mySQL,MYSQL_READ_DEFAULT_GROUP,"scastd");
 
-	username = getenv("SCASTD_USER");
-	if (username != 0) {
-		strcpy(u, username);
-	}
-	else {
-		strcpy(u, "root");
-	}
-	password = getenv("SCASTD_PASSWORD");
-	if (password != 0) {
-		strcpy(p, password);
-	}
-	else {
-		strcpy(p, "");
-	}
-	
+        if (username && *username) {
+                strcpy(u, username);
+        }
+        else {
+                strcpy(u, "root");
+        }
+        if (password && *password) {
+                strcpy(p, password);
+        }
+        else {
+                strcpy(p, "");
+        }
+
         if (!mysql_real_connect(&mySQL,"localhost",u,p,"scastd",0,NULL,0)) {
                 fprintf(stderr, "Failed to connect to database: Error: %s\n", mysql_error(&mySQL));
                 return(0);
         }
-	return 1;
+        return 1;
 }
 int DB::Query(char *query) {
-	// double	startTime = 0.0;
-	// double	endTime = 0.0;
+        // double       startTime = 0.0;
+        // double       endTime = 0.0;
 
-	numFetches = 0;
-	strcpy(tempQuery, query);
-	if (sqlTimings) {
-		startTime = DBGetCurrentTime();
-	}
-	if (pResult) {
-		mysql_free_result(pResult);
-	}
+        numFetches = 0;
+        strcpy(tempQuery, query);
+        if (sqlTimings) {
+                startTime = DBGetCurrentTime();
+        }
+        if (pResult) {
+                mysql_free_result(pResult);
+        }
         if (mysql_query(&mySQL, query) != 0) {
                 fprintf(stderr, "Misformed query (%s)\n", query);
                 fprintf(stderr, "Error: %s\n", mysql_error(&mySQL));
@@ -103,33 +99,33 @@ int DB::Query(char *query) {
 
         pResult = mysql_store_result(&mySQL);
         if (pResult) {
-		numFields = mysql_num_fields(pResult);
-		numRows = mysql_num_rows(pResult);
+                numFields = mysql_num_fields(pResult);
+                numRows = mysql_num_rows(pResult);
         }
-	if (sqlTimings) {
-		endTime = DBGetCurrentTime();
-	}
+        if (sqlTimings) {
+                endTime = DBGetCurrentTime();
+        }
 
-	if (sqlTimings) {
-		fprintf(stdout, "Query %f secs - SQL: %s\n", endTime - startTime, query);
-	}
-	return(1);
+        if (sqlTimings) {
+                fprintf(stdout, "Query %f secs - SQL: %s\n", endTime - startTime, query);
+        }
+        return(1);
 
 }
 MYSQL_ROW DB::Fetch() {
-	numFetches++;
-	return mysql_fetch_row(pResult);
+        numFetches++;
+        return mysql_fetch_row(pResult);
 }
 
 void DB::EndQuery() {
-	if (sqlTimings) {
-		endTime = DBGetCurrentTime();
-	}
-	if (sqlTimings) {
-		fprintf(stdout, "Total Time Query (%d fetches) %f secs - SQL: %s\n", numFetches, endTime - startTime, tempQuery);
-	}
+        if (sqlTimings) {
+                endTime = DBGetCurrentTime();
+        }
+        if (sqlTimings) {
+                fprintf(stdout, "Total Time Query (%d fetches) %f secs - SQL: %s\n", numFetches, endTime - startTime, tempQuery);
+        }
 }
 void DB::Disconnect() {
-	mysql_close(&mySQL);
-	return;
+        mysql_close(&mySQL);
+        return;
 }

--- a/src/DB.h
+++ b/src/DB.h
@@ -37,7 +37,7 @@ public:
 	double	endTime;
 	char	tempQuery[2046];
 
-	int Connect();
+        int Connect(const char *username, const char *password);
 	void Disconnect();
 	int Query(char *);
 	void EndQuery();

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 PACKAGE=scastd
 VERSION=0.1
 AUTOMAKE=automake
-OBJS=Socket.o DB.o
+OBJS=Socket.o DB.o Config.o
 
 EXEC=scastd
 CXXFLAGS=@CXXFLAGS@

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,7 +1,7 @@
 PACKAGE=scastd
 VERSION=0.1
 AUTOMAKE=automake
-OBJS=Socket.o DB.o
+OBJS=Socket.o DB.o Config.o
 
 EXEC=scastd
 CXXFLAGS=@CXXFLAGS@

--- a/src/run_scastd.sh
+++ b/src/run_scastd.sh
@@ -7,9 +7,6 @@ if [ $1 = "help" ]; then
 echo"Please enter a username and password for mysql i.e. ./install.sh root password"
 fi
 if [ $1 != "" ]; then
-export SCASTD_USER=$1
-export SCASTD_PASSWORD=$2
-
 echo "Creating and importing the default scastd database and schema"
 mysqladmin --user=$1 --password=$2 create scastd
 mysql --user=$1 --password=$2 scastd < scastd.sql

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <libxml/parser.h>
 #include <signal.h>
 #include "DB.h"
+#include "Config.h"
 
 #include "Socket.h"
 
@@ -122,6 +123,7 @@ main(int argc, char **argv)
 	xmlDocPtr doc;
 	DB	db;
 	DB	db2;
+        Config  cfg;
 
 	char *contentType;
 	char	request[1024];
@@ -142,6 +144,16 @@ main(int argc, char **argv)
 	char	*p3;
 	int	sleeptime = 0;
 	int	insert_flag = 0;
+        std::string configPath = "scastd.conf";
+        if (argc > 1) {
+                configPath = argv[1];
+        }
+        if (!cfg.Load(configPath)) {
+                fprintf(stderr, "Cannot load config file %s\n", configPath.c_str());
+                exit(1);
+        }
+        std::string dbUser = cfg.Get("username", "root");
+        std::string dbPass = cfg.Get("password", "");
 
 	fprintf(stdout, "Detaching from console...\n");
 
@@ -160,8 +172,8 @@ main(int argc, char **argv)
 		fprintf(stderr, "Cannot install handler for SIGUSR2\n");
 		exit(1);
 	}
-	db.Connect();
-	db2.Connect();
+        db.Connect(dbUser.c_str(), dbPass.c_str());
+        db2.Connect(dbUser.c_str(), dbPass.c_str());
 	sprintf(query, "select sleeptime, logfile from scastd_runtime");
 	db.Query(query);
 	row = db.Fetch();


### PR DESCRIPTION
## Summary
- Introduce simple key-value config parser and sample `scastd.conf`
- Switch DB connection to read credentials from configuration
- Load config in `scastd` and pass user/password to DB layer
- Drop environment variables from scripts and documentation

## Testing
- `cd src && make clean && make` *(fails: g++: warning: @CXXFLAGS@: linker input file unused because linking not done; g++: error: @CXXFLAGS@: linker input file not found)*
- `./configure` *(fails: configure: error: cannot find required auxiliary files: compile)*

------
https://chatgpt.com/codex/tasks/task_e_68962d5ec6a4832b8e77442cc04aaece