### PR TITLE
Simplify build bootstrap with autoreconf

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,63 +1,20 @@
 #!/bin/sh
 # Run this to set up the build system: configure, makefiles, etc.
-# (based on the version in enlightenment's cvs)
+
+set -e
 
 package="scastd"
 
-olddir=`pwd`
-srcdir=`dirname $0`
+olddir=$(pwd)
+srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
-
 cd "$srcdir"
-DIE=0
-
-(autoconf --version) < /dev/null > /dev/null 2>&1 || {
-        echo
-        echo "You must have autoconf installed to compile $package."
-        echo "Download the appropriate package for your distribution,"
-        echo "or get the source tarball at ftp://ftp.gnu.org/pub/gnu/"
-        DIE=1
-}
-
-(automake --version) < /dev/null > /dev/null 2>&1 || {
-        echo
-        echo "You must have automake installed to compile $package."
-	echo "Download the appropriate package for your system,
-	echo "or get the source from one of the GNU ftp sites"
-	echo "listed in http://www.gnu.org/order/ftp.html"
-        DIE=1
-}
-
-(libtool --version) < /dev/null > /dev/null 2>&1 || {
-	echo
-	echo "You must have libtool installed to compile $package."
-	echo "Download the appropriate package for your system,
-	echo "or get the source from one of the GNU ftp sites"
-	echo "listed in http://www.gnu.org/order/ftp.html"
-	DIE=1
-}
-
-if test "$DIE" -eq 1; then
-        exit 1
-fi
-
-if test -z "$*"; then
-        echo "I am going to run ./configure with no arguments - if you wish "
-        echo "to pass any to it, please specify them on the $0 command line."
-fi
 
 echo "Generating configuration files for $package, please wait...."
+autoreconf --install --force --verbose
 
-echo "  aclocal $ACLOCAL_FLAGS"
-aclocal $ACLOCAL_FLAGS
-#echo "  autoheader"
-#autoheader
-echo "  libtoolize --automake"
-libtoolize --automake
-echo "  automake --add-missing"
-automake --add-missing 
-echo "  autoconf"
-autoconf
+cd "$olddir"
 
-cd $olddir
-$srcdir/configure "$@" && echo
+echo
+echo "Now run ./configure [options]"
+


### PR DESCRIPTION
## Summary
- Replace manual autotools invocations with a single `autoreconf --install --force --verbose`
- Remove hand-written tool version checks and prompt users to run `./configure` themselves

## Testing
- `sh -n autogen.sh`
- `./autogen.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896673252e0832ba9a6496e66a144f5