### PR TITLE
Define main return type and exit code

### DIFF
--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -118,7 +118,7 @@ typedef struct tagServerData {
 	char	songTitle[1024];
 } serverData;
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 	xmlDocPtr doc;
 	IDatabase       *db = NULL;
@@ -326,4 +326,5 @@ main(int argc, char **argv)
 		sleep(sleeptime);
 	}
 	}
+	return 0;
 }


### PR DESCRIPTION
## Summary
- specify `int main(int argc, char **argv)` in scastd.cpp
- return 0 from `main` before final closing brace

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6896ea7cdac8832b94f0849b7ce19fa6