### PR TITLE
Add m4 macro directory and update build scripts

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -11,7 +11,7 @@ test -z "$srcdir" && srcdir=.
 cd "$srcdir"
 
 echo "Generating configuration files for $package, please wait...."
-autoreconf --install --force --verbose
+autoreconf -I m4 --install --force --verbose
 
 cd "$olddir"
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT([scastd],[1.0])
+AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([src/scastd.cpp])
 AC_CONFIG_HEADERS([config.h])

--- a/m4/.gitkeep
+++ b/m4/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure directory is tracked by git.


### PR DESCRIPTION
## Summary
- Create `m4/` directory for custom autoconf macros
- Register macro directory in `configure.ac`
- Call `autoreconf` with `-I m4` in `autogen.sh`

## Testing
- `./autogen.sh` *(fails: Can't exec "aclocal")*

------
https://chatgpt.com/codex/tasks/task_e_6896ebacde3c832b888814931b388f0e