### PR TITLE
docs: add build troubleshooting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ username root
 password secret
 ```
 
+
+Troubleshooting
+---------------
+If the build fails, common issues and fixes include:
+
+- `aclocal`: command not found – install the `automake` package.
+- `AM_PROG_LIBTOOL` missing – install `libtool`.
+- Missing `mariadb/mysql.h` or `mysql.h` – install `libmariadb-dev` and `libmariadb-dev-compat`.
+
+After installing the required packages, rerun `./autogen.sh`,
+`./configure CXXFLAGS='-std=c++17 -g -O2'`, and `make`.  Tests (if any)
+can be executed with `make check`.


### PR DESCRIPTION
## Summary
- document common build failures and required packages

## Testing
- `./autogen.sh`
- `./configure CXXFLAGS='-std=c++17 -g -O2'`
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6896ec7382f8832b88e8042ed11e8c4f