### PR TITLE
Add PostgreSQL schema and modernize MySQL dump

### DIFF
--- a/docs/DatabaseMigration.md
+++ b/docs/DatabaseMigration.md
@@ -33,3 +33,21 @@ support `ENGINE=MyISAM` directives present in some MySQL schemas. MariaDB follow
 but may need `ROW_FORMAT` adjustments for older MySQL dumps.
 
 Refer to your database documentation when porting existing schemas.
+
+### MySQL / MariaDB
+
+The provided dump at `src/scastd.sql` has been modernized for MySQL 8 and MariaDB 10.11:
+
+* Deprecated `timestamp(14)` and `int(11)` types were replaced with `TIMESTAMP` and `INT`.
+* All tables declare `ENGINE=InnoDB` with `CHARSET=utf8mb4` and `COLLATE=utf8mb4_unicode_ci`.
+* Every column specifies an explicit `DEFAULT` clause, and auto-incrementing keys use
+  `AUTO_INCREMENT`.
+
+### PostgreSQL
+
+An equivalent schema and seed data are available in `src/scastd_pg.sql`. Key differences from the
+MySQL dialect include:
+
+* `SERIAL` is used for auto-incrementing identifiers.
+* Character fields rely on PostgreSQL's `TEXT` type and inherit database encoding (typically UTF‑8).
+* Default values use `CURRENT_TIMESTAMP`, `CURRENT_DATE` and `CURRENT_TIME` expressions.

--- a/src/scastd.sql
+++ b/src/scastd.sql
@@ -14,7 +14,7 @@ CREATE TABLE scastd_memberinfo (
   password varchar(155) DEFAULT '' NOT NULL,
   gather_flag varchar(155) DEFAULT '' NOT NULL,
   PRIMARY KEY (serverURL)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 #
 # Dumping data for table 'scastd_memberinfo'
@@ -28,9 +28,9 @@ INSERT INTO scastd_memberinfo VALUES ('http://boa.mediacast1.com:9908','party732
 
 DROP TABLE IF EXISTS scastd_runtime;
 CREATE TABLE scastd_runtime (
-  sleeptime int(11),
-  logfile varchar(255)
-);
+  sleeptime INT DEFAULT NULL,
+  logfile VARCHAR(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 #
 # Dumping data for table 'scastd_runtime'
@@ -44,14 +44,14 @@ INSERT INTO scastd_runtime VALUES (30,'./scastd.log');
 
 DROP TABLE IF EXISTS scastd_serverinfo;
 CREATE TABLE scastd_serverinfo (
-  serverURL varchar(255),
-  currentlisteners int(11),
-  peaklisteners int(11),
-  maxlisteners int(11),
-  averagetime int(11),
-  streamhits int(11),
-  time timestamp(14)
-);
+  serverURL VARCHAR(255) DEFAULT NULL,
+  currentlisteners INT DEFAULT NULL,
+  peaklisteners INT DEFAULT NULL,
+  maxlisteners INT DEFAULT NULL,
+  averagetime INT DEFAULT NULL,
+  streamhits INT DEFAULT NULL,
+  time TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 #
 # Dumping data for table 'scastd_serverinfo'
@@ -64,10 +64,10 @@ CREATE TABLE scastd_serverinfo (
 
 DROP TABLE IF EXISTS scastd_songinfo;
 CREATE TABLE scastd_songinfo (
-  serverURL varchar(255),
-  songTitle varchar(255),
-  time timestamp(14)
-);
+  serverURL VARCHAR(255) DEFAULT NULL,
+  songTitle VARCHAR(255) DEFAULT NULL,
+  time TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 #
 # Dumping data for table 'scastd_songinfo'
@@ -80,29 +80,29 @@ CREATE TABLE scastd_songinfo (
 
 DROP TABLE IF EXISTS scastd_xml;
 CREATE TABLE scastd_xml (
-  id int(10) NOT NULL auto_increment,
-  currentlisteners varchar(155) DEFAULT '' NOT NULL,
-  peaklisteners varchar(155) DEFAULT '' NOT NULL,
-  maxlisteners varchar(155) DEFAULT '' NOT NULL,
-  reportedlisteners varchar(155) DEFAULT '' NOT NULL,
-  averagetime varchar(255) DEFAULT '' NOT NULL,
-  servergenre varchar(155) DEFAULT '' NOT NULL,
-  serverurl varchar(255) DEFAULT '' NOT NULL,
-  servertitle varchar(255) DEFAULT '' NOT NULL,
-  currentsong varchar(255) DEFAULT '' NOT NULL,
-  webhits varchar(155) DEFAULT '' NOT NULL,
-  streamhits varchar(255) DEFAULT '' NOT NULL,
-  hostname varchar(255) DEFAULT '' NOT NULL,
-  useragent varchar(255) DEFAULT '' NOT NULL,
-  connecttime varchar(155) DEFAULT '' NOT NULL,
-  songtitle varchar(255) DEFAULT '' NOT NULL,
-  playedat varchar(55) DEFAULT '' NOT NULL,
-  bwidthus varchar(55) DEFAULT '' NOT NULL,
-  totbwidthus varchar(255) DEFAULT '' NOT NULL,
-  date date DEFAULT '0000-00-00' NOT NULL,
-  time time DEFAULT '00:00:00' NOT NULL,
+  id INT NOT NULL AUTO_INCREMENT,
+  currentlisteners VARCHAR(155) DEFAULT '' NOT NULL,
+  peaklisteners VARCHAR(155) DEFAULT '' NOT NULL,
+  maxlisteners VARCHAR(155) DEFAULT '' NOT NULL,
+  reportedlisteners VARCHAR(155) DEFAULT '' NOT NULL,
+  averagetime VARCHAR(255) DEFAULT '' NOT NULL,
+  servergenre VARCHAR(155) DEFAULT '' NOT NULL,
+  serverurl VARCHAR(255) DEFAULT '' NOT NULL,
+  servertitle VARCHAR(255) DEFAULT '' NOT NULL,
+  currentsong VARCHAR(255) DEFAULT '' NOT NULL,
+  webhits VARCHAR(155) DEFAULT '' NOT NULL,
+  streamhits VARCHAR(255) DEFAULT '' NOT NULL,
+  hostname VARCHAR(255) DEFAULT '' NOT NULL,
+  useragent VARCHAR(255) DEFAULT '' NOT NULL,
+  connecttime VARCHAR(155) DEFAULT '' NOT NULL,
+  songtitle VARCHAR(255) DEFAULT '' NOT NULL,
+  playedat VARCHAR(55) DEFAULT '' NOT NULL,
+  bwidthus VARCHAR(55) DEFAULT '' NOT NULL,
+  totbwidthus VARCHAR(255) DEFAULT '' NOT NULL,
+  date DATE DEFAULT '1970-01-01' NOT NULL,
+  time TIME DEFAULT '00:00:00' NOT NULL,
   PRIMARY KEY (id)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 #
 # Dumping data for table 'scastd_xml'

--- a/src/scastd_pg.sql
+++ b/src/scastd_pg.sql
@@ -1,0 +1,69 @@
+-- PostgreSQL schema for scastd
+
+-- Table structure for table 'scastd_memberinfo'
+DROP TABLE IF EXISTS scastd_memberinfo;
+CREATE TABLE scastd_memberinfo (
+  serverURL TEXT PRIMARY KEY,
+  password TEXT NOT NULL DEFAULT '',
+  gather_flag TEXT NOT NULL DEFAULT ''
+);
+
+-- Dumping data for table 'scastd_memberinfo'
+INSERT INTO scastd_memberinfo (serverURL, password, gather_flag) VALUES
+  ('http://boa.mediacast1.com:9908', 'party7324', '1');
+
+-- Table structure for table 'scastd_runtime'
+DROP TABLE IF EXISTS scastd_runtime;
+CREATE TABLE scastd_runtime (
+  sleeptime INTEGER,
+  logfile TEXT
+);
+
+-- Dumping data for table 'scastd_runtime'
+INSERT INTO scastd_runtime (sleeptime, logfile) VALUES (30, './scastd.log');
+
+-- Table structure for table 'scastd_serverinfo'
+DROP TABLE IF EXISTS scastd_serverinfo;
+CREATE TABLE scastd_serverinfo (
+  serverURL TEXT,
+  currentlisteners INTEGER,
+  peaklisteners INTEGER,
+  maxlisteners INTEGER,
+  averagetime INTEGER,
+  streamhits INTEGER,
+  time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table structure for table 'scastd_songinfo'
+DROP TABLE IF EXISTS scastd_songinfo;
+CREATE TABLE scastd_songinfo (
+  serverURL TEXT,
+  songTitle TEXT,
+  time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table structure for table 'scastd_xml'
+DROP TABLE IF EXISTS scastd_xml;
+CREATE TABLE scastd_xml (
+  id SERIAL PRIMARY KEY,
+  currentlisteners TEXT NOT NULL DEFAULT '',
+  peaklisteners TEXT NOT NULL DEFAULT '',
+  maxlisteners TEXT NOT NULL DEFAULT '',
+  reportedlisteners TEXT NOT NULL DEFAULT '',
+  averagetime TEXT NOT NULL DEFAULT '',
+  servergenre TEXT NOT NULL DEFAULT '',
+  serverurl TEXT NOT NULL DEFAULT '',
+  servertitle TEXT NOT NULL DEFAULT '',
+  currentsong TEXT NOT NULL DEFAULT '',
+  webhits TEXT NOT NULL DEFAULT '',
+  streamhits TEXT NOT NULL DEFAULT '',
+  hostname TEXT NOT NULL DEFAULT '',
+  useragent TEXT NOT NULL DEFAULT '',
+  connecttime TEXT NOT NULL DEFAULT '',
+  songtitle TEXT NOT NULL DEFAULT '',
+  playedat TEXT NOT NULL DEFAULT '',
+  bwidthus TEXT NOT NULL DEFAULT '',
+  totbwidthus TEXT NOT NULL DEFAULT '',
+  date DATE NOT NULL DEFAULT CURRENT_DATE,
+  time TIME NOT NULL DEFAULT CURRENT_TIME
+);


### PR DESCRIPTION
## Summary
- Modernize MySQL dump with explicit defaults, InnoDB engine, utf8mb4 charset/collation and updated INT/TIMESTAMP types
- Introduce PostgreSQL schema and seed data
- Document MySQL vs PostgreSQL schema differences

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68977117d4d4832b8b6bd4d4ea684be3