### PR TITLE
Add database connection configuration

### DIFF
--- a/scastd.conf
+++ b/scastd.conf
@@ -3,3 +3,26 @@
 username root
 password secret
 DatabaseType mysql
+host localhost
+port 3306
+dbname scastd
+# sslmode disable
+
+# Example MySQL 8 setup
+# DatabaseType mysql
+# host 127.0.0.1
+# port 3306
+# dbname scastd
+
+# Example MariaDB 10.11 setup
+# DatabaseType mariadb
+# host 127.0.0.1
+# port 3306
+# dbname scastd
+
+# Example PostgreSQL setup
+# DatabaseType postgres
+# host 127.0.0.1
+# port 5432
+# dbname scastd
+# sslmode require

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -34,3 +34,15 @@ std::string Config::Get(const std::string &key, const std::string &def) const {
     }
     return def;
 }
+
+int Config::Get(const std::string &key, int def) const {
+    std::map<std::string, std::string>::const_iterator it = values.find(key);
+    if (it != values.end()) {
+        try {
+            return std::stoi(it->second);
+        } catch (...) {
+            return def;
+        }
+    }
+    return def;
+}

--- a/src/Config.h
+++ b/src/Config.h
@@ -8,6 +8,7 @@ class Config {
 public:
     bool Load(const std::string &path);
     std::string Get(const std::string &key, const std::string &def = "") const;
+    int Get(const std::string &key, int def) const;
 private:
     std::map<std::string, std::string> values;
 };

--- a/src/db/IDatabase.h
+++ b/src/db/IDatabase.h
@@ -8,7 +8,12 @@ class IDatabase {
 public:
     using Row = std::vector<std::string>;
     virtual ~IDatabase() {}
-    virtual bool connect(const std::string &username, const std::string &password) = 0;
+    virtual bool connect(const std::string &username,
+                        const std::string &password,
+                        const std::string &host,
+                        int port,
+                        const std::string &dbname,
+                        const std::string &sslmode) = 0;
     virtual bool query(const std::string &query) = 0;
     virtual Row fetch() = 0;
     virtual void disconnect() = 0;

--- a/src/db/MariaDBDatabase.cpp
+++ b/src/db/MariaDBDatabase.cpp
@@ -13,9 +13,15 @@ MariaDBDatabase::~MariaDBDatabase() {
     mysql_close(&mySQL);
 }
 
-bool MariaDBDatabase::connect(const std::string &username, const std::string &password) {
+bool MariaDBDatabase::connect(const std::string &username,
+                              const std::string &password,
+                              const std::string &host,
+                              int port,
+                              const std::string &dbname,
+                              const std::string &sslmode) {
     mysql_options(&mySQL, MYSQL_READ_DEFAULT_GROUP, "scastd");
-    if (!mysql_real_connect(&mySQL, "localhost", username.c_str(), password.c_str(), "scastd", 0, NULL, 0)) {
+    (void)sslmode;
+    if (!mysql_real_connect(&mySQL, host.c_str(), username.c_str(), password.c_str(), dbname.c_str(), port, NULL, 0)) {
         std::cerr << "Failed to connect to database: " << mysql_error(&mySQL) << std::endl;
         return false;
     }

--- a/src/db/MariaDBDatabase.h
+++ b/src/db/MariaDBDatabase.h
@@ -9,7 +9,12 @@ public:
     MariaDBDatabase();
     ~MariaDBDatabase();
 
-    bool connect(const std::string &username, const std::string &password) override;
+    bool connect(const std::string &username,
+                 const std::string &password,
+                 const std::string &host,
+                 int port,
+                 const std::string &dbname,
+                 const std::string &sslmode) override;
     bool query(const std::string &query) override;
     Row fetch() override;
     void disconnect() override;

--- a/src/db/MySQLDatabase.cpp
+++ b/src/db/MySQLDatabase.cpp
@@ -13,9 +13,15 @@ MySQLDatabase::~MySQLDatabase() {
     mysql_close(&mySQL);
 }
 
-bool MySQLDatabase::connect(const std::string &username, const std::string &password) {
+bool MySQLDatabase::connect(const std::string &username,
+                            const std::string &password,
+                            const std::string &host,
+                            int port,
+                            const std::string &dbname,
+                            const std::string &sslmode) {
     mysql_options(&mySQL, MYSQL_READ_DEFAULT_GROUP, "scastd");
-    if (!mysql_real_connect(&mySQL, "localhost", username.c_str(), password.c_str(), "scastd", 0, NULL, 0)) {
+    (void)sslmode;
+    if (!mysql_real_connect(&mySQL, host.c_str(), username.c_str(), password.c_str(), dbname.c_str(), port, NULL, 0)) {
         std::cerr << "Failed to connect to database: " << mysql_error(&mySQL) << std::endl;
         return false;
     }

--- a/src/db/MySQLDatabase.h
+++ b/src/db/MySQLDatabase.h
@@ -9,7 +9,12 @@ public:
     MySQLDatabase();
     ~MySQLDatabase();
 
-    bool connect(const std::string &username, const std::string &password) override;
+    bool connect(const std::string &username,
+                 const std::string &password,
+                 const std::string &host,
+                 int port,
+                 const std::string &dbname,
+                 const std::string &sslmode) override;
     bool query(const std::string &query) override;
     Row fetch() override;
     void disconnect() override;

--- a/src/db/PostgresDatabase.cpp
+++ b/src/db/PostgresDatabase.cpp
@@ -12,8 +12,20 @@ PostgresDatabase::~PostgresDatabase() {
     }
 }
 
-bool PostgresDatabase::connect(const std::string &username, const std::string &password) {
-    std::string conninfo = "user=" + username + " password=" + password + " dbname=scastd host=localhost";
+bool PostgresDatabase::connect(const std::string &username,
+                               const std::string &password,
+                               const std::string &host,
+                               int port,
+                               const std::string &dbname,
+                               const std::string &sslmode) {
+    std::string conninfo = "user=" + username + " password=" + password +
+                           " dbname=" + dbname + " host=" + host;
+    if (port > 0) {
+        conninfo += " port=" + std::to_string(port);
+    }
+    if (!sslmode.empty()) {
+        conninfo += " sslmode=" + sslmode;
+    }
     conn = PQconnectdb(conninfo.c_str());
     if (PQstatus(conn) != CONNECTION_OK) {
         std::cerr << "Failed to connect to database: " << PQerrorMessage(conn) << std::endl;

--- a/src/db/PostgresDatabase.h
+++ b/src/db/PostgresDatabase.h
@@ -9,7 +9,12 @@ public:
     PostgresDatabase();
     ~PostgresDatabase();
 
-    bool connect(const std::string &username, const std::string &password) override;
+    bool connect(const std::string &username,
+                 const std::string &password,
+                 const std::string &host,
+                 int port,
+                 const std::string &dbname,
+                 const std::string &sslmode) override;
     bool query(const std::string &query) override;
     Row fetch() override;
     void disconnect() override;

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -150,6 +150,10 @@ int main(int argc, char **argv)
         std::string dbUser = cfg.Get("username", "root");
         std::string dbPass = cfg.Get("password", "");
         std::string dbType = cfg.Get("DatabaseType", "mysql");
+        std::string dbHost = cfg.Get("host", "localhost");
+        int dbPort = cfg.Get("port", 0);
+        std::string dbName = cfg.Get("dbname", "scastd");
+        std::string dbSSLMode = cfg.Get("sslmode", "");
         if (dbType == "mysql") {
                 db = new MySQLDatabase();
                 db2 = new MySQLDatabase();
@@ -181,8 +185,8 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Cannot install handler for SIGUSR2\n");
 		exit(1);
 	}
-        db->connect(dbUser.c_str(), dbPass.c_str());
-        db2->connect(dbUser.c_str(), dbPass.c_str());
+        db->connect(dbUser, dbPass, dbHost, dbPort, dbName, dbSSLMode);
+        db2->connect(dbUser, dbPass, dbHost, dbPort, dbName, dbSSLMode);
         sprintf(query, "select sleeptime, logfile from scastd_runtime");
         db->query(query);
         row = db->fetch();


### PR DESCRIPTION
## Summary
- Allow configuring database host, port, name, and optional sslmode in `scastd.conf`
- Expose numeric config retrieval and extend DB connection interfaces
- Use new parameters when connecting to MySQL, MariaDB, or PostgreSQL

## Testing
- `./autogen.sh`
- `./configure`
- `make` *(fails: mariadb/mysql.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689772ad04f8832ba1880c7031049fc8