### PR TITLE
Add lightweight HTTP status server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Building
 This repository omits generated build system files such as `configure` and `Makefile.in`.
 Run `./autogen.sh` (or `autoreconf -i && ./configure`) to generate them before building:
 
+Install the required development packages, including
+`libmicrohttpd-dev` on Debian/Ubuntu or `libmicrohttpd` via Homebrew on
+macOS, then run:
+
 ```
 ./autogen.sh
 make
@@ -44,6 +48,7 @@ If the build fails, common issues and fixes include:
 - `aclocal`: command not found – install the `automake` package.
 - `AM_PROG_LIBTOOL` missing – install `libtool`.
 - Missing `mariadb/mysql.h` or `mysql.h` – install `libmariadb-dev` and `libmariadb-dev-compat`.
+- `microhttpd.h` missing – install `libmicrohttpd-dev`.
 
 After installing the required packages, rerun `./autogen.sh`,
 `./configure CXXFLAGS='-std=c++17 -g -O2'`, and `make`.  Tests (if any)

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ dnl Use a modern C++ compiler with Linux specific options
 CXXFLAGS="$CXXFLAGS -std=c++17 -Wall -D_GNU_SOURCE"
 
 dnl Checks for required libraries
-PKG_CHECK_MODULES([DEPS], [libxml-2.0 libcurl mysqlclient libpq])
+PKG_CHECK_MODULES([DEPS], [libxml-2.0 libcurl mysqlclient libpq libmicrohttpd])
 CXXFLAGS="$CXXFLAGS $DEPS_CFLAGS"
 LIBS="$LIBS $DEPS_LIBS"
 

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -1,0 +1,99 @@
+#include "HttpServer.h"
+
+#include <cstring>
+#include <csignal>
+#include <string>
+#include <unistd.h>
+
+namespace {
+HttpServer *g_server = nullptr;
+
+void handle_signal(int) {
+    if (g_server) {
+        g_server->stop();
+    }
+    _exit(0);
+}
+
+static const char kJsonResponse[] = "{\"status\":\"ok\"}";
+static const char kXmlResponse[] = "<status>ok</status>";
+}
+
+HttpServer::HttpServer() : running_(false), daemon_(nullptr) {}
+
+HttpServer::~HttpServer() {
+    stop();
+}
+
+bool HttpServer::start() {
+#if defined(__APPLE__) || defined(__linux__)
+    if (daemon(0, 0) != 0) {
+        return false;
+    }
+#endif
+    g_server = this;
+    std::signal(SIGINT, handle_signal);
+    std::signal(SIGTERM, handle_signal);
+
+    daemon_ = MHD_start_daemon(MHD_USE_INTERNAL_POLLING_THREAD,
+                               8333,
+                               nullptr, nullptr,
+                               &HttpServer::handleRequest, this,
+                               MHD_OPTION_END);
+    running_ = daemon_ != nullptr;
+    return running_;
+}
+
+void HttpServer::stop() {
+    if (running_) {
+        MHD_stop_daemon(daemon_);
+        daemon_ = nullptr;
+        running_ = false;
+    }
+}
+
+MHD_Result HttpServer::handleRequest(void *cls,
+                                     struct MHD_Connection *connection,
+                                     const char *url,
+                                     const char *method,
+                                     const char *version,
+                                     const char *upload_data,
+                                     size_t *upload_data_size,
+                                     void **con_cls) {
+    (void)cls;
+    (void)version;
+    (void)upload_data;
+    (void)upload_data_size;
+    (void)con_cls;
+
+    if (std::strcmp(method, "GET") != 0) {
+        return MHD_NO;
+    }
+
+    const char *page = nullptr;
+    const char *content_type = nullptr;
+
+    if (std::strcmp(url, "/status.json") == 0) {
+        page = kJsonResponse;
+        content_type = "application/json";
+    } else if (std::strcmp(url, "/status.xml") == 0) {
+        page = kXmlResponse;
+        content_type = "application/xml";
+    } else {
+        static const char not_found[] = "Not Found";
+        struct MHD_Response *response = MHD_create_response_from_buffer(
+            sizeof(not_found) - 1, (void *)not_found, MHD_RESPMEM_PERSISTENT);
+        MHD_add_response_header(response, "Content-Type", "text/plain");
+        int ret = MHD_queue_response(connection, MHD_HTTP_NOT_FOUND, response);
+        MHD_destroy_response(response);
+        return static_cast<MHD_Result>(ret);
+    }
+
+    struct MHD_Response *response = MHD_create_response_from_buffer(
+        std::strlen(page), (void *)page, MHD_RESPMEM_PERSISTENT);
+    MHD_add_response_header(response, "Content-Type", content_type);
+    int ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
+    MHD_destroy_response(response);
+    return static_cast<MHD_Result>(ret);
+}
+

--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <atomic>
+#include <microhttpd.h>
+
+class HttpServer {
+public:
+    HttpServer();
+    ~HttpServer();
+
+    bool start();
+    void stop();
+
+private:
+    static MHD_Result handleRequest(void *cls,
+                                    struct MHD_Connection *connection,
+                                    const char *url,
+                                    const char *method,
+                                    const char *version,
+                                    const char *upload_data,
+                                    size_t *upload_data_size,
+                                    void **con_cls);
+
+    std::atomic<bool> running_;
+    struct MHD_Daemon *daemon_;
+};
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,2 +1,2 @@
 bin_PROGRAMS = scastd
-scastd_SOURCES = scastd.cpp Config.cpp CurlWrapper.cpp db/MySQLDatabase.cpp db/MariaDBDatabase.cpp db/PostgresDatabase.cpp
+scastd_SOURCES = scastd.cpp Config.cpp CurlWrapper.cpp HttpServer.cpp db/MySQLDatabase.cpp db/MariaDBDatabase.cpp db/PostgresDatabase.cpp

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -36,6 +36,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "Config.h"
 
 #include "CurlWrapper.h"
+#include "HttpServer.h"
 
 FILE	*filep_log = 0;
 char	logfile[2046] = "";
@@ -120,7 +121,8 @@ typedef struct tagServerData {
 
 int main(int argc, char **argv)
 {
-	xmlDocPtr doc;
+        HttpServer httpServer;
+        xmlDocPtr doc;
 	IDatabase       *db = NULL;
 	IDatabase       *db2 = NULL;
         Config  cfg;
@@ -146,6 +148,9 @@ int main(int argc, char **argv)
         if (!cfg.Load(configPath)) {
                 fprintf(stderr, "Cannot load config file %s\n", configPath.c_str());
                 exit(1);
+        }
+        if (!httpServer.start()) {
+                fprintf(stderr, "Failed to start HTTP server\n");
         }
         std::string dbUser = cfg.Get("username", "root");
         std::string dbPass = cfg.Get("password", "");
@@ -329,6 +334,7 @@ int main(int argc, char **argv)
 		writeToLog(buf);
 		sleep(sleeptime);
 	}
-	}
-	return 0;
+        }
+        httpServer.stop();
+        return 0;
 }


### PR DESCRIPTION
## Summary
- add libmicrohttpd-based HttpServer with JSON and XML status endpoints
- start server from scastd and support signal-based shutdown and daemonization
- document new libmicrohttpd dependency and register server sources in build system

## Testing
- `./autogen.sh`
- `./configure`
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68977463bee0832bb05721e8f1cb8890