### PR TITLE
Add Icecast2 statistics client

### DIFF
--- a/docs/Icecast2.md
+++ b/docs/Icecast2.md
@@ -1,0 +1,30 @@
+# Icecast2 Statistics Fetcher
+
+The `Icecast2` class retrieves runtime statistics from an Icecast server using
+HTTP and exposes key fields such as listener counts, bitrates and the currently
+playing track. It authenticates with the Icecast administrative interface using
+HTTP Basic authentication and parses the returned `stats.xml` document.
+
+## Example
+
+```cpp
+#include "icecast2.h"
+#include <iostream>
+
+int main() {
+    Icecast2 client("stream.example.com", 8000, "admin", "hackme");
+    std::vector<Icecast2::StreamInfo> stats;
+    std::string err;
+    if (client.fetchStats(stats, err)) {
+        for (const auto &s : stats) {
+            std::cout << s.mount << ": " << s.listeners << " listeners\n";
+        }
+    } else {
+        std::cerr << "Failed to fetch stats: " << err << std::endl;
+    }
+    return 0;
+}
+```
+
+The `fetchStats` method returns a vector of `StreamInfo` structures which can be
+used by the existing database layer to record real‑time stream statistics.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,2 +1,2 @@
 bin_PROGRAMS = scastd
-scastd_SOURCES = scastd.cpp Config.cpp CurlWrapper.cpp HttpServer.cpp db/MySQLDatabase.cpp db/MariaDBDatabase.cpp db/PostgresDatabase.cpp
+scastd_SOURCES = scastd.cpp Config.cpp CurlWrapper.cpp HttpServer.cpp icecast2.cpp db/MySQLDatabase.cpp db/MariaDBDatabase.cpp db/PostgresDatabase.cpp

--- a/src/icecast2.cpp
+++ b/src/icecast2.cpp
@@ -1,0 +1,107 @@
+#include "icecast2.h"
+
+#include <curl/curl.h>
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+#include <cstdlib>
+
+namespace {
+size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
+    size_t totalSize = size * nmemb;
+    std::string *s = static_cast<std::string *>(userp);
+    s->append(static_cast<char *>(contents), totalSize);
+    return totalSize;
+}
+}
+
+Icecast2::Icecast2(const std::string &h,
+                   int p,
+                   const std::string &user,
+                   const std::string &pass)
+    : host(h), port(p), username(user), password(pass) {}
+
+bool Icecast2::fetchStats(std::vector<StreamInfo> &stats, std::string &error) const {
+    CURL *curl = curl_easy_init();
+    if (!curl) {
+        error = "Failed to initialize curl";
+        return false;
+    }
+
+    std::string url = "http://" + host + ":" + std::to_string(port) + "/admin/stats.xml";
+    std::string response;
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_easy_setopt(curl, CURLOPT_USERNAME, username.c_str());
+    curl_easy_setopt(curl, CURLOPT_PASSWORD, password.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "scastd/1.0");
+
+    CURLcode res = curl_easy_perform(curl);
+    long http_code = 0;
+    if (res == CURLE_OK) {
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    }
+    curl_easy_cleanup(curl);
+
+    if (res != CURLE_OK) {
+        error = curl_easy_strerror(res);
+        return false;
+    }
+    if (http_code != 200) {
+        error = "HTTP response code " + std::to_string(http_code);
+        return false;
+    }
+
+    xmlDocPtr doc = xmlParseMemory(response.c_str(), response.size());
+    if (!doc) {
+        error = "Failed to parse XML";
+        return false;
+    }
+
+    xmlNodePtr root = xmlDocGetRootElement(doc);
+    if (!root || xmlStrcmp(root->name, BAD_CAST "icestats") != 0) {
+        xmlFreeDoc(doc);
+        error = "Unexpected XML format";
+        return false;
+    }
+
+    for (xmlNodePtr node = root->children; node; node = node->next) {
+        if (node->type != XML_ELEMENT_NODE) {
+            continue;
+        }
+        if (xmlStrcmp(node->name, BAD_CAST "source") == 0) {
+            StreamInfo info;
+            xmlChar *mount = xmlGetProp(node, BAD_CAST "mount");
+            if (mount) {
+                info.mount = reinterpret_cast<char *>(mount);
+                xmlFree(mount);
+            }
+            info.listeners = 0;
+            info.bitrate = 0;
+            for (xmlNodePtr child = node->children; child; child = child->next) {
+                if (child->type != XML_ELEMENT_NODE) {
+                    continue;
+                }
+                xmlChar *content = xmlNodeGetContent(child);
+                if (!content) {
+                    continue;
+                }
+                if (xmlStrcmp(child->name, BAD_CAST "listeners") == 0) {
+                    info.listeners = std::atoi(reinterpret_cast<char *>(content));
+                } else if (xmlStrcmp(child->name, BAD_CAST "bitrate") == 0) {
+                    info.bitrate = std::atoi(reinterpret_cast<char *>(content));
+                } else if (xmlStrcmp(child->name, BAD_CAST "title") == 0) {
+                    info.title = reinterpret_cast<char *>(content);
+                }
+                xmlFree(content);
+            }
+            stats.push_back(info);
+        }
+    }
+
+    xmlFreeDoc(doc);
+    return true;
+}
+

--- a/src/icecast2.h
+++ b/src/icecast2.h
@@ -1,0 +1,33 @@
+#ifndef ICECAST2_H
+#define ICECAST2_H
+
+#include <string>
+#include <vector>
+
+// Fetch Icecast server statistics via HTTP and expose basic fields.
+class Icecast2 {
+public:
+    struct StreamInfo {
+        std::string mount;     // mountpoint name
+        int listeners;         // current number of listeners
+        int bitrate;           // stream bitrate in kbps
+        std::string title;     // currently playing track
+    };
+
+    Icecast2(const std::string &host,
+             int port,
+             const std::string &username,
+             const std::string &password);
+
+    // Fetch statistics from the server. Returns true on success.
+    // On failure returns false and stores the error message in `error`.
+    bool fetchStats(std::vector<StreamInfo> &stats, std::string &error) const;
+
+private:
+    std::string host;
+    int port;
+    std::string username;
+    std::string password;
+};
+
+#endif // ICECAST2_H


### PR DESCRIPTION
## Summary
- add `Icecast2` class that retrieves Icecast admin stats with libcurl and parses XML for listeners, bitrate and track title
- document how to use the `Icecast2` client
- wire new source file into build system

## Testing
- `./autogen.sh`
- `./configure`
- `make` *(fails: mariadb/mysql.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68977638d4a8832ba37ec71cfdd89767