### PR TITLE
Add configurable HTTP server settings

### DIFF
--- a/scastd.conf
+++ b/scastd.conf
@@ -8,6 +8,12 @@ port 3306
 dbname scastd
 # sslmode disable
 
+# HTTP server configuration
+# Enable or disable the built-in HTTP status server (default: true)
+http_enabled true
+# Port for the HTTP status server (default: 8333)
+http_port 8333
+
 # Example MySQL 8 setup
 # DatabaseType mysql
 # host 127.0.0.1

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,6 +1,8 @@
 #include "Config.h"
 #include <fstream>
 #include <sstream>
+#include <algorithm>
+#include <cctype>
 
 bool Config::Load(const std::string &path) {
     std::ifstream in(path.c_str());
@@ -42,6 +44,22 @@ int Config::Get(const std::string &key, int def) const {
             return std::stoi(it->second);
         } catch (...) {
             return def;
+        }
+    }
+    return def;
+}
+
+bool Config::Get(const std::string &key, bool def) const {
+    std::map<std::string, std::string>::const_iterator it = values.find(key);
+    if (it != values.end()) {
+        std::string val = it->second;
+        std::transform(val.begin(), val.end(), val.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        if (val == "1" || val == "true" || val == "yes" || val == "on") {
+            return true;
+        }
+        if (val == "0" || val == "false" || val == "no" || val == "off") {
+            return false;
         }
     }
     return def;

--- a/src/Config.h
+++ b/src/Config.h
@@ -9,6 +9,7 @@ public:
     bool Load(const std::string &path);
     std::string Get(const std::string &key, const std::string &def = "") const;
     int Get(const std::string &key, int def) const;
+    bool Get(const std::string &key, bool def) const;
 private:
     std::map<std::string, std::string> values;
 };

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -25,7 +25,7 @@ HttpServer::~HttpServer() {
     stop();
 }
 
-bool HttpServer::start() {
+bool HttpServer::start(int port) {
 #if defined(__APPLE__) || defined(__linux__)
     if (daemon(0, 0) != 0) {
         return false;
@@ -36,7 +36,7 @@ bool HttpServer::start() {
     std::signal(SIGTERM, handle_signal);
 
     daemon_ = MHD_start_daemon(MHD_USE_INTERNAL_POLLING_THREAD,
-                               8333,
+                               port,
                                nullptr, nullptr,
                                &HttpServer::handleRequest, this,
                                MHD_OPTION_END);

--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -8,7 +8,7 @@ public:
     HttpServer();
     ~HttpServer();
 
-    bool start();
+    bool start(int port = 8333);
     void stop();
 
 private:

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -149,8 +149,12 @@ int main(int argc, char **argv)
                 fprintf(stderr, "Cannot load config file %s\n", configPath.c_str());
                 exit(1);
         }
-        if (!httpServer.start()) {
-                fprintf(stderr, "Failed to start HTTP server\n");
+        bool httpEnabled = cfg.Get("http_enabled", true);
+        int httpPort = cfg.Get("http_port", 8333);
+        if (httpEnabled) {
+                if (!httpServer.start(httpPort)) {
+                        fprintf(stderr, "Failed to start HTTP server on port %d\n", httpPort);
+                }
         }
         std::string dbUser = cfg.Get("username", "root");
         std::string dbPass = cfg.Get("password", "");


### PR DESCRIPTION
## Summary
- add `http_enabled` and `http_port` options with defaults in `scastd.conf`
- allow `Config` to parse boolean values
- start HTTP server only when enabled and allow port override

## Testing
- `./autogen.sh`
- `./configure` *(fails: Package requirements (libxml-2.0 libcurl mysqlclient libpq libmicrohttpd) were not met)*

------
https://chatgpt.com/codex/tasks/task_e_689777e56e58832bb48b9d356ff52bbc