### PR TITLE
docs: describe HTTP server and platform builds

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,44 @@ The following libraries are required to build scastd:
 * libmicrohttpd or Boost.Beast
 * libcurl
 
+Platform-specific build notes
+-----------------------------
+
+macOS (arm64)
+~~~~~~~~~~~~~
+Install tools and libraries using Homebrew:
+
+```
+brew install autoconf automake libtool pkg-config \
+             libmicrohttpd libcurl mariadb-connector-c postgresql
+```
+
+Then build and run the tests:
+
+```
+./autogen.sh
+./configure
+make && make check
+```
+
+Linux (x86_64)
+~~~~~~~~~~~~~~
+Install dependencies with APT:
+
+```
+sudo apt-get install build-essential autoconf automake libtool pkg-config \
+                     libmicrohttpd-dev libcurl4-openssl-dev libmariadb-dev \
+                     libpq-dev
+```
+
+Then build and run the tests:
+
+```
+./autogen.sh
+./configure
+make && make check
+```
+
 Basic Installation
 ==================
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Public License along with this program; if not, write to the Free Software Found
 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
+Overview
+--------
+scastd is a small daemon for collecting Icecast2 stream statistics and
+publishing them over HTTP.  It polls an Icecast2 server for current
+listener information, stores the results in a database, and exposes a
+lightweight web service built with `libmicrohttpd`.  The HTTP server
+listens on port **8333** and serves JSON or XML status responses at
+`/status.json` and `/status.xml`.  Database backends for MariaDB/MySQL
+and PostgreSQL are currently supported.
+
 Building
 --------
 This repository omits generated build system files such as `configure` and `Makefile.in`.
@@ -38,6 +48,16 @@ Example `scastd.conf`:
 # database credentials
 username root
 password secret
+```
+
+Usage
+-----
+Start the daemon with your configuration file and query the HTTP
+endpoint:
+
+```
+./src/scastd scastd.conf &
+curl http://localhost:8333/status.json
 ```
 
 


### PR DESCRIPTION
## Summary
- document HTTP server, DB backends, Icecast2 stats retrieval
- add usage examples for daemon and status query
- add platform-specific build instructions for macOS arm64 and Linux x86_64

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6897cb646a38832b94763e006df95305