### PR TITLE
Add PostgreSQL config example and note required client library

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,6 +5,7 @@ The following libraries are required to build scastd:
 
 * libmicrohttpd or Boost.Beast
 * libcurl
+* libpq (PostgreSQL client library)
 
 Platform-specific build notes
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Building
 This repository omits generated build system files such as `configure` and `Makefile.in`.
 Run `./autogen.sh` (or `autoreconf -i && ./configure`) to generate them before building:
 
-Install the required development packages, including
-`libmicrohttpd-dev` on Debian/Ubuntu or `libmicrohttpd` via Homebrew on
-macOS, then run:
+Install the required development packages, including `libmicrohttpd-dev`
+and `libpq-dev` on Debian/Ubuntu or `libmicrohttpd` and `postgresql`
+via Homebrew on macOS, then run:
 
 ```
 ./autogen.sh

--- a/scastd_pg.conf
+++ b/scastd_pg.conf
@@ -1,0 +1,13 @@
+# Sample scastd configuration for PostgreSQL
+# Lines starting with # are comments
+
+# database credentials
+username postgres
+password secret
+
+# PostgreSQL connection settings
+DatabaseType postgres
+host 127.0.0.1
+port 5432
+dbname scastd
+sslmode require


### PR DESCRIPTION
## Summary
- add `scastd_pg.conf` example showing typical PostgreSQL settings
- document libpq/PostgreSQL client libraries in install and build docs

## Testing
- `./configure` *(fails: Package 'mysqlclient', required by 'virtual:world', not found)*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_6897cd1a5b80832ba1faae053062b001