### PR TITLE
Improve DatabaseType error handling

### DIFF
--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -173,8 +173,10 @@ int main(int argc, char **argv)
                 db = new PostgresDatabase();
                 db2 = new PostgresDatabase();
         } else {
-                fprintf(stderr, "Unknown DatabaseType %s\n", dbType.c_str());
-                exit(1);
+                fprintf(stderr, "Unknown DatabaseType '%s'. Supported values are mysql, mariadb, postgres. Falling back to default 'mysql'.\n", dbType.c_str());
+                db = new MySQLDatabase();
+                db2 = new MySQLDatabase();
+                dbType = "mysql";
         }
 
         fprintf(stdout, "Detaching from console...\n");


### PR DESCRIPTION
## Summary
- Clarify DatabaseType configuration errors by listing supported values
- Fall back to MySQL when an invalid DatabaseType is configured

## Testing
- `./autogen.sh`
- `DEPS_CFLAGS="$(pkg-config --cflags libxml-2.0 libpq libcurl mariadb libmicrohttpd)" DEPS_LIBS="$(pkg-config --libs libxml-2.0 libpq libcurl mariadb libmicrohttpd)" ./configure`
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6897d6243c1c832ba6ba2b5baa516f96