### PR TITLE
Support env and secret file credential overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ username root
 password secret
 ```
 
+For security, make the configuration file readable only by your user:
+
+```
+chmod 600 scastd.conf
+```
+
+The `username` and `password` settings may be supplied via environment
+variables. `SCASTD_USERNAME` and `SCASTD_PASSWORD` override values in the
+configuration file. Alternatively, `SCASTD_USERNAME_FILE` or
+`SCASTD_PASSWORD_FILE` can point to files containing the corresponding
+credential. The configuration file also supports `username_file` and
+`password_file` keys. Any secrets file should also be protected with
+restrictive permissions, for example `chmod 600 password.txt`.
+
 Usage
 -----
 Start the daemon with your configuration file and query the HTTP

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -2,6 +2,7 @@
 #include "Config.h"
 #include <fstream>
 #include <cstdio>
+#include <cstdlib>
 
 TEST_CASE("Config parsing") {
     const char* fname = "test.conf";
@@ -18,4 +19,50 @@ TEST_CASE("Config parsing") {
     REQUIRE(cfg.Get("missing", 42) == 42);
 
     std::remove(fname);
+}
+
+TEST_CASE("Environment and secret overrides") {
+    const char* cfg = "test.conf";
+    std::ofstream out(cfg);
+    out << "username fileuser\n";
+    out << "password filepass\n";
+    out.close();
+
+    // environment variables override config
+    setenv("SCASTD_USERNAME", "envuser", 1);
+    setenv("SCASTD_PASSWORD", "envpass", 1);
+    Config envcfg;
+    REQUIRE(envcfg.Load(cfg));
+    REQUIRE(envcfg.Get("username", "") == std::string("envuser"));
+    REQUIRE(envcfg.Get("password", "") == std::string("envpass"));
+    unsetenv("SCASTD_USERNAME");
+    unsetenv("SCASTD_PASSWORD");
+
+    // secret files via environment variables
+    const char* ufile = "user.secret";
+    const char* pfile = "pass.secret";
+    std::ofstream uf(ufile); uf << "ufile\n"; uf.close();
+    std::ofstream pf(pfile); pf << "pfile\n"; pf.close();
+    setenv("SCASTD_USERNAME_FILE", ufile, 1);
+    setenv("SCASTD_PASSWORD_FILE", pfile, 1);
+    Config filecfg;
+    REQUIRE(filecfg.Load(cfg));
+    REQUIRE(filecfg.Get("username", "") == std::string("ufile"));
+    REQUIRE(filecfg.Get("password", "") == std::string("pfile"));
+    unsetenv("SCASTD_USERNAME_FILE");
+    unsetenv("SCASTD_PASSWORD_FILE");
+
+    // secret files via configuration entries
+    std::ofstream out2(cfg);
+    out2 << "username_file " << ufile << "\n";
+    out2 << "password_file " << pfile << "\n";
+    out2.close();
+    Config cfgfile;
+    REQUIRE(cfgfile.Load(cfg));
+    REQUIRE(cfgfile.Get("username", "") == std::string("ufile"));
+    REQUIRE(cfgfile.Get("password", "") == std::string("pfile"));
+
+    std::remove(ufile);
+    std::remove(pfile);
+    std::remove(cfg);
 }


### PR DESCRIPTION
## Summary
- document protecting config files and describe env var overrides
- allow credentials to be overridden by environment variables or secret files
- add tests for env and secret overrides

## Testing
- `./autogen.sh`
- `./configure`
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6897db390544832b8f47d59b5b020a5d