### PR TITLE
Add configurable log rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Example `scastd.conf`:
 # database credentials
 username root
 password secret
+# log configuration
+log_dir ./logs
+log_max_size 1048576
+log_retention 5
 ```
 
 For security, make the configuration file readable only by your user:

--- a/scastd.conf
+++ b/scastd.conf
@@ -8,6 +8,14 @@ port 3306
 dbname scastd
 # sslmode disable
 
+# Logging configuration
+# Directory for log files
+log_dir ./logs
+# Maximum size of a log file in bytes before rotation
+log_max_size 1048576
+# Number of rotated log files to keep
+log_retention 5
+
 # HTTP server configuration
 # Enable or disable the built-in HTTP status server (default: true)
 http_enabled true


### PR DESCRIPTION
## Summary
- rotate logs when size limit is exceeded or day changes
- allow configuring log directory, max log size and retention count
- document new logging settings in README

## Testing
- `autoreconf -i` *(fails: Can't exec "aclocal")*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6897dce742a4832ba454e40a25c9e964