### PR TITLE
Handle IPv6 URLs in parser

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,6 +4,7 @@ scastd_SOURCES = \
     Config.cpp \
     CurlWrapper.cpp \
     HttpServer.cpp \
+    UrlParser.cpp \
     icecast2.cpp \
     db/MySQLDatabase.cpp \
     db/MariaDBDatabase.cpp \

--- a/src/UrlParser.cpp
+++ b/src/UrlParser.cpp
@@ -1,0 +1,28 @@
+#include "UrlParser.h"
+#include <cstring>
+#include <cstdlib>
+
+bool parseHostPort(const std::string &url, std::string &host, int &port) {
+    const char *scheme = "http://";
+    size_t start = 0;
+    if (url.compare(0, std::strlen(scheme), scheme) == 0) {
+        start = std::strlen(scheme);
+    }
+    if (start >= url.size()) return false;
+    if (url[start] == '[') {
+        size_t end = url.find(']', start);
+        if (end == std::string::npos) return false;
+        host = url.substr(start + 1, end - start - 1);
+        size_t colon = url.find(':', end);
+        if (colon == std::string::npos) return false;
+        port = std::atoi(url.c_str() + colon + 1);
+        return true;
+    } else {
+        size_t colon = url.find(':', start);
+        if (colon == std::string::npos) return false;
+        host = url.substr(start, colon - start);
+        port = std::atoi(url.c_str() + colon + 1);
+        return true;
+    }
+}
+

--- a/src/UrlParser.h
+++ b/src/UrlParser.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+
+bool parseHostPort(const std::string &url, std::string &host, int &port);
+

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -41,6 +41,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "CurlWrapper.h"
 #include "HttpServer.h"
+#include "UrlParser.h"
 
 FILE	*filep_log = 0;
 char	logfile[2046] = "";
@@ -196,8 +197,6 @@ int main(int argc, char **argv)
 	char	IP[255] = "";
 	int	port = 0;
 	char	password[255] = "";
-	char	*p2;
-	char	*p3;
 	int	sleeptime = 0;
 	int	insert_flag = 0;
         std::string configPath = "scastd.conf";
@@ -291,15 +290,10 @@ int main(int argc, char **argv)
                                 port = 0;
                                 if (!row[0].empty()) {
                                         strcpy(serverURL, row[0].c_str());
-                                        p2 = strstr(serverURL, "http://");
-                                        if (p2) {
-                                                p2 = p2 + strlen("http://");
-                                                p3 = strchr(p2, ':');
-                                                if (p3) {
-                                                        strncpy(IP, p2, p3-p2);
-                                                        p3++;
-                                                        port = atoi(p3);
-                                                }
+                                        std::string ipStr;
+                                        if (parseHostPort(row[0], ipStr, port)) {
+                                                strncpy(IP, ipStr.c_str(), sizeof(IP) - 1);
+                                                IP[sizeof(IP) - 1] = '\0';
                                         }
 
                                 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,8 +1,8 @@
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) -DTEST_SRCDIR=\"$(top_srcdir)\"
 
 check_PROGRAMS = unit_tests
-unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp \
-    ../src/Config.cpp ../src/HttpServer.cpp ../src/icecast2.cpp
+unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_url_parser.cpp \
+    ../src/Config.cpp ../src/HttpServer.cpp ../src/icecast2.cpp ../src/UrlParser.cpp
 unit_tests_LDADD = $(DEPS_LIBS)
 
 TESTS = unit_tests

--- a/tests/test_url_parser.cpp
+++ b/tests/test_url_parser.cpp
@@ -1,0 +1,18 @@
+#include "catch.hpp"
+#include "UrlParser.h"
+
+TEST_CASE("parseHostPort handles IPv4") {
+    std::string host;
+    int port = 0;
+    REQUIRE(parseHostPort("http://192.0.2.1:8000", host, port));
+    REQUIRE(host == "192.0.2.1");
+    REQUIRE(port == 8000);
+}
+
+TEST_CASE("parseHostPort handles IPv6") {
+    std::string host;
+    int port = 0;
+    REQUIRE(parseHostPort("http://[2001:db8::1]:8000", host, port));
+    REQUIRE(host == "2001:db8::1");
+    REQUIRE(port == 8000);
+}


### PR DESCRIPTION
## Summary
- add UrlParser utility to split host and port, including [IPv6] addresses
- update scastd to use new parser
- test IPv4 and IPv6 host parsing

## Testing
- `make -C tests check`

------
https://chatgpt.com/codex/tasks/task_e_6897df5603cc832b88817b7ab7fbfaea