### PR TITLE
Namespace HttpServer and Icecast2 classes

### DIFF
--- a/docs/Icecast2.md
+++ b/docs/Icecast2.md
@@ -1,6 +1,6 @@
 # Icecast2 Statistics Fetcher
 
-The `Icecast2` class retrieves runtime statistics from an Icecast server using
+The `scastd::Icecast2` class retrieves runtime statistics from an Icecast server using
 HTTP and exposes key fields such as listener counts, bitrates and the currently
 playing track. It authenticates with the Icecast administrative interface using
 HTTP Basic authentication and parses the returned `stats.xml` document.
@@ -12,8 +12,8 @@ HTTP Basic authentication and parses the returned `stats.xml` document.
 #include <iostream>
 
 int main() {
-    Icecast2 client("stream.example.com", 8000, "admin", "hackme");
-    std::vector<Icecast2::StreamInfo> stats;
+    scastd::Icecast2 client("stream.example.com", 8000, "admin", "hackme");
+    std::vector<scastd::Icecast2::StreamInfo> stats;
     std::string err;
     if (client.fetchStats(stats, err)) {
         for (const auto &s : stats) {

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -6,6 +6,8 @@
 #include <unistd.h>
 #include <cstdlib>
 
+namespace scastd {
+
 namespace {
 HttpServer *g_server = nullptr;
 
@@ -18,7 +20,7 @@ void handle_signal(int) {
 
 static const char kJsonResponse[] = "{\"status\":\"ok\"}";
 static const char kXmlResponse[] = "<status>ok</status>";
-}
+} // namespace
 
 HttpServer::HttpServer() : running_(false), daemon_(nullptr) {}
 
@@ -100,4 +102,6 @@ MHD_Result HttpServer::handleRequest(void *cls,
     MHD_destroy_response(response);
     return static_cast<MHD_Result>(ret);
 }
+
+} // namespace scastd
 

--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -3,6 +3,8 @@
 #include <atomic>
 #include <microhttpd.h>
 
+namespace scastd {
+
 class HttpServer {
 public:
     HttpServer();
@@ -24,4 +26,6 @@ private:
     std::atomic<bool> running_;
     struct MHD_Daemon *daemon_;
 };
+
+} // namespace scastd
 

--- a/src/icecast2.cpp
+++ b/src/icecast2.cpp
@@ -5,6 +5,8 @@
 #include <libxml/tree.h>
 #include <cstdlib>
 
+namespace scastd {
+
 namespace {
 size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
     size_t totalSize = size * nmemb;
@@ -104,4 +106,6 @@ bool Icecast2::fetchStats(std::vector<StreamInfo> &stats, std::string &error) co
     xmlFreeDoc(doc);
     return true;
 }
+
+} // namespace scastd
 

--- a/src/icecast2.h
+++ b/src/icecast2.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+namespace scastd {
+
 // Fetch Icecast server statistics via HTTP and expose basic fields.
 class Icecast2 {
 public:
@@ -29,5 +31,7 @@ private:
     std::string username;
     std::string password;
 };
+
+} // namespace scastd
 
 #endif // ICECAST2_H

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -181,7 +181,7 @@ typedef struct tagServerData {
 
 int main(int argc, char **argv)
 {
-        HttpServer httpServer;
+        scastd::HttpServer httpServer;
         xmlDocPtr doc;
 	IDatabase       *db = NULL;
 	IDatabase       *db2 = NULL;

--- a/tests/test_http.cpp
+++ b/tests/test_http.cpp
@@ -15,7 +15,7 @@ static size_t write_cb(void *contents, size_t size, size_t nmemb, void *userp) {
 
 TEST_CASE("HTTP server responds with status") {
     setenv("SCASD_NO_DAEMON", "1", 1);
-    HttpServer server;
+    scastd::HttpServer server;
     REQUIRE(server.start(18080));
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 

--- a/tests/test_icecast.cpp
+++ b/tests/test_icecast.cpp
@@ -39,8 +39,8 @@ TEST_CASE("Icecast2 parses XML stats") {
     std::string xml = "<icestats><source mount=\"/stream\"><listeners>5</listeners><bitrate>128</bitrate><title>Test</title></source></icestats>";
     StatsServer server(xml);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    Icecast2 ice("localhost", 18081, "", "");
-    std::vector<Icecast2::StreamInfo> stats;
+    scastd::Icecast2 ice("localhost", 18081, "", "");
+    std::vector<scastd::Icecast2::StreamInfo> stats;
     std::string err;
     REQUIRE(ice.fetchStats(stats, err));
     REQUIRE(err.empty());


### PR DESCRIPTION
## Summary
- Wrap HttpServer and Icecast2 implementations in the `scastd` namespace
- Update tests, main program, and documentation to use the new namespace

## Testing
- `g++ -std=c++17 -DCATCH_CONFIG_MAIN -I src tests/test_http.cpp src/HttpServer.cpp -o test_http -lcurl -lmicrohttpd -lpthread`
- `./test_http`
- `g++ -std=c++17 -DCATCH_CONFIG_MAIN -I src -I/usr/include/libxml2 tests/test_icecast.cpp src/icecast2.cpp -o test_icecast -lcurl -lmicrohttpd -lxml2 -lpthread`
- `./test_icecast`


------
https://chatgpt.com/codex/tasks/task_e_6897e9f4b454832bad3a106570fd13f0