### PR TITLE
Add GPL license headers and licensing instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,8 @@
+# AGENTS Instructions
+
+All `*.cpp` and `*.h` files must start with the following GPL license header:
+
+```
 /*
 /////////////////////////////////////////////////
 // Scast Daemon
@@ -19,34 +24,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 */
-#pragma once
+```
 
-#include <atomic>
-#include <microhttpd.h>
-
-namespace scastd {
-
-class HttpServer {
-public:
-    HttpServer();
-    ~HttpServer();
-
-    bool start(int port = 8333);
-    void stop();
-
-private:
-    static MHD_Result handleRequest(void *cls,
-                                    struct MHD_Connection *connection,
-                                    const char *url,
-                                    const char *method,
-                                    const char *version,
-                                    const char *upload_data,
-                                    size_t *upload_data_size,
-                                    void **con_cls);
-
-    std::atomic<bool> running_;
-    struct MHD_Daemon *daemon_;
-};
-
-} // namespace scastd
-
+New source files must include this header to comply with project licensing.

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -1,3 +1,24 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
 #include "HttpServer.h"
 
 #include <cstring>

--- a/src/icecast2.cpp
+++ b/src/icecast2.cpp
@@ -1,3 +1,24 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
 #include "icecast2.h"
 
 #include <curl/curl.h>

--- a/src/icecast2.h
+++ b/src/icecast2.h
@@ -1,3 +1,24 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
 #ifndef ICECAST2_H
 #define ICECAST2_H
 


### PR DESCRIPTION
## Summary
- add GPL license header to HttpServer and Icecast sources
- document GPL header requirement in AGENTS.md for future files

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6897f85abda4832bab606e62d16815f2