### PR TITLE
Handle SIGHUP for runtime config reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ endpoint:
 curl http://localhost:8333/status.json
 ```
 
+Send `SIGHUP` to the running process to reload `scastd.conf`. Updated
+settings such as the log directory or database credentials take effect
+without restarting.
+
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
## Summary
- reload configuration on SIGHUP, updating log settings and DB connections
- document sending SIGHUP to reload config

## Testing
- `./autogen.sh`
- `./configure`
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6897ffdd30c0832b803fe416ee6df0be