### PR TITLE
Add cURL timeout, IPv6, and user-agent options

### DIFF
--- a/src/CurlWrapper.cpp
+++ b/src/CurlWrapper.cpp
@@ -1,3 +1,25 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #include "CurlWrapper.h"
 
 #include <curl/curl.h>
@@ -11,7 +33,8 @@ size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
 }
 }
 
-bool fetchUrl(const std::string &url, std::string &response) {
+bool fetchUrl(const std::string &url, std::string &response,
+              long timeout, bool ipv6, const std::string &userAgent) {
     CURL *curl = curl_easy_init();
     if (!curl) {
         return false;
@@ -20,7 +43,13 @@ bool fetchUrl(const std::string &url, std::string &response) {
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, "Mozilla/4.0 (compatible; scastd)");
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, userAgent.c_str());
+    if (timeout > 0) {
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
+    }
+    if (ipv6) {
+        curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
+    }
 
     CURLcode res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);

--- a/src/CurlWrapper.h
+++ b/src/CurlWrapper.h
@@ -1,8 +1,32 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #pragma once
 
 #include <string>
 
 // Fetch the content at the given URL using libcurl.
 // Returns true on success and stores the response body in `response`.
-bool fetchUrl(const std::string &url, std::string &response);
+bool fetchUrl(const std::string &url, std::string &response,
+              long timeout = 0, bool ipv6 = false,
+              const std::string &userAgent = "Mozilla/4.0 (compatible; scastd)");
 


### PR DESCRIPTION
## Summary
- allow callers to specify timeout, IPv6 resolution, and user-agent when fetching URLs
- add GPL license headers to CurlWrapper sources

## Testing
- `g++ -std=c++17 -c src/CurlWrapper.cpp -lcurl`
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68980309f754832b9b19d0b2734f63bb