### PR TITLE
Improve dependency checks and documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,9 +3,11 @@ Dependencies
 
 The following libraries are required to build scastd:
 
-* libmicrohttpd or Boost.Beast
+* libxml2
 * libcurl
+* MySQL client library (libmysqlclient or MariaDB equivalent)
 * libpq (PostgreSQL client library)
+* libmicrohttpd
 
 Platform-specific build notes
 -----------------------------
@@ -37,7 +39,7 @@ Install Apple's command line tools and Homebrew, then fetch build dependencies.
 
    ```
    brew install autoconf automake libtool pkg-config \
-                libmicrohttpd libcurl mariadb-connector-c postgresql
+                libmicrohttpd libcurl libxml2 mariadb-connector-c postgresql
    ```
 
 Then build and run the tests:
@@ -55,7 +57,7 @@ Install dependencies with APT:
 ```
 sudo apt-get install build-essential autoconf automake libtool pkg-config \
                      libmicrohttpd-dev libcurl4-openssl-dev libmariadb-dev \
-                     libpq-dev
+                     libpq-dev libxml2-dev
 ```
 
 Then build and run the tests:

--- a/configure.ac
+++ b/configure.ac
@@ -13,9 +13,29 @@ dnl Use a modern C++ compiler with Linux specific options
 CXXFLAGS="$CXXFLAGS -std=c++17 -Wall -D_GNU_SOURCE"
 
 dnl Checks for required libraries
-PKG_CHECK_MODULES([DEPS], [libxml-2.0 libcurl mysqlclient libpq libmicrohttpd])
-CXXFLAGS="$CXXFLAGS $DEPS_CFLAGS"
-LIBS="$LIBS $DEPS_LIBS"
+PKG_CHECK_MODULES([LIBXML2], [libxml-2.0], [], [AC_MSG_ERROR([libxml2 library not found; install libxml2-dev.])])
+CXXFLAGS="$CXXFLAGS $LIBXML2_CFLAGS"
+LIBS="$LIBS $LIBXML2_LIBS"
+
+PKG_CHECK_MODULES([LIBCURL], [libcurl], [], [AC_MSG_ERROR([libcurl library not found; install libcurl development files.])])
+CXXFLAGS="$CXXFLAGS $LIBCURL_CFLAGS"
+LIBS="$LIBS $LIBCURL_LIBS"
+
+PKG_CHECK_MODULES([MYSQLCLIENT], [mysqlclient],
+  [CXXFLAGS="$CXXFLAGS $MYSQLCLIENT_CFLAGS"
+   LIBS="$LIBS $MYSQLCLIENT_LIBS"],
+  [PKG_CHECK_MODULES([MYSQLCLIENT], [libmariadb],
+     [CXXFLAGS="$CXXFLAGS $MYSQLCLIENT_CFLAGS"
+      LIBS="$LIBS $MYSQLCLIENT_LIBS"],
+     [AC_MSG_ERROR([MySQL client library not found; install libmysqlclient-dev or libmariadb-dev.])])])
+
+PKG_CHECK_MODULES([LIBPQ], [libpq], [], [AC_MSG_ERROR([PostgreSQL client library (libpq) not found; install libpq-dev.])])
+CXXFLAGS="$CXXFLAGS $LIBPQ_CFLAGS"
+LIBS="$LIBS $LIBPQ_LIBS"
+
+PKG_CHECK_MODULES([LIBMICROHTTPD], [libmicrohttpd], [], [AC_MSG_ERROR([libmicrohttpd library not found; install libmicrohttpd-dev.])])
+CXXFLAGS="$CXXFLAGS $LIBMICROHTTPD_CFLAGS"
+LIBS="$LIBS $LIBMICROHTTPD_LIBS"
 
 dnl Make substitutions
 AC_SUBST(CXXFLAGS)


### PR DESCRIPTION
## Summary
- Fail fast with clear messages when required libraries are missing
- Document all build dependencies and platform-specific install commands

## Testing
- `./autogen.sh`
- `./configure`
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689804eadf00832b89cb561ec28eb4f9