### PR TITLE
Introduce CurlClient and inject into Icecast2

### DIFF
--- a/docs/Icecast2.md
+++ b/docs/Icecast2.md
@@ -8,11 +8,13 @@ HTTP Basic authentication and parses the returned `stats.xml` document.
 ## Example
 
 ```cpp
+#include "CurlClient.h"
 #include "icecast2.h"
 #include <iostream>
 
 int main() {
-    scastd::Icecast2 client("stream.example.com", 8000, "admin", "hackme");
+    CurlClient http;
+    scastd::Icecast2 client("stream.example.com", 8000, "admin", "hackme", http);
     std::vector<scastd::Icecast2::StreamInfo> stats;
     std::string err;
     if (client.fetchStats(stats, err)) {

--- a/src/CurlClient.cpp
+++ b/src/CurlClient.cpp
@@ -20,7 +20,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 */
 
-#include "CurlWrapper.h"
+#include "CurlClient.h"
 
 #include <curl/curl.h>
 
@@ -33,8 +33,10 @@ size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
 }
 }
 
-bool fetchUrl(const std::string &url, std::string &response,
-              long timeout, bool ipv6, const std::string &userAgent) {
+bool CurlClient::fetchUrl(const std::string &url, std::string &response,
+                          long timeout, bool ipv6,
+                          const std::string &userAgent,
+                          long *httpCode) const {
     CURL *curl = curl_easy_init();
     if (!curl) {
         return false;
@@ -52,6 +54,9 @@ bool fetchUrl(const std::string &url, std::string &response,
     }
 
     CURLcode res = curl_easy_perform(curl);
+    if (res == CURLE_OK && httpCode) {
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, httpCode);
+    }
     curl_easy_cleanup(curl);
 
     return res == CURLE_OK;

--- a/src/CurlClient.h
+++ b/src/CurlClient.h
@@ -24,9 +24,20 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include <string>
 
-// Fetch the content at the given URL using libcurl.
-// Returns true on success and stores the response body in `response`.
-bool fetchUrl(const std::string &url, std::string &response,
-              long timeout = 0, bool ipv6 = false,
-              const std::string &userAgent = "Mozilla/4.0 (compatible; scastd)");
+// Simple HTTP client built on top of libcurl.  Methods are virtual to allow
+// tests to provide mock implementations.
+class CurlClient {
+public:
+    virtual ~CurlClient() = default;
+
+    // Fetch the content at the given URL using libcurl.  Returns true on
+    // success and stores the response body in `response`.  If `httpCode` is
+    // non-null it will be populated with the HTTP status code from the
+    // response.
+    virtual bool fetchUrl(const std::string &url, std::string &response,
+                          long timeout = 0, bool ipv6 = false,
+                          const std::string &userAgent =
+                              "Mozilla/4.0 (compatible; scastd)",
+                          long *httpCode = nullptr) const;
+};
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = scastd
 scastd_SOURCES = \
     scastd.cpp \
     Config.cpp \
-    CurlWrapper.cpp \
+    CurlClient.cpp \
     HttpServer.cpp \
     UrlParser.cpp \
     icecast2.cpp \

--- a/src/icecast2.h
+++ b/src/icecast2.h
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <string>
 #include <vector>
 
+#include "CurlClient.h"
+
 namespace scastd {
 
 // Fetch Icecast server statistics via HTTP and expose basic fields.
@@ -40,7 +42,8 @@ public:
     Icecast2(const std::string &host,
              int port,
              const std::string &username,
-             const std::string &password);
+             const std::string &password,
+             const CurlClient &client);
 
     // Fetch statistics from the server. Returns true on success.
     // On failure returns false and stores the error message in `error`.
@@ -51,6 +54,7 @@ private:
     int port;
     std::string username;
     std::string password;
+    const CurlClient &http;
 };
 
 } // namespace scastd

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -39,7 +39,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "db/PostgresDatabase.h"
 #include "Config.h"
 
-#include "CurlWrapper.h"
+#include "CurlClient.h"
 #include "HttpServer.h"
 #include "UrlParser.h"
 
@@ -396,7 +396,8 @@ int main(int argc, char **argv)
                                 writeToLog(buf);
                                 std::string url = std::string("http://") + IP + ":" + std::to_string(port) + "/admin.cgi?pass=" + password + "&mode=viewxml";
                                 std::string response;
-                                if (fetchUrl(url, response)) {
+                                CurlClient curl;
+                                if (curl.fetchUrl(url, response)) {
                                         if (response.find("<title>SHOUTcast Administrator</title>") != std::string::npos) {
                                                 sprintf(buf, "Bad password (%s/%s)\n", serverURL, password);
                                                 writeToLog(buf);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) -DTEST_SR
 
 check_PROGRAMS = unit_tests
 unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_url_parser.cpp \
-    ../src/Config.cpp ../src/HttpServer.cpp ../src/icecast2.cpp ../src/UrlParser.cpp
+    ../src/Config.cpp ../src/HttpServer.cpp ../src/icecast2.cpp ../src/UrlParser.cpp \
+    ../src/CurlClient.cpp
 unit_tests_LDADD = $(DEPS_LIBS)
 
 TESTS = unit_tests

--- a/tests/test_icecast.cpp
+++ b/tests/test_icecast.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "icecast2.h"
+#include "CurlClient.h"
 #include <microhttpd.h>
 #include <string>
 #include <vector>
@@ -39,7 +40,8 @@ TEST_CASE("Icecast2 parses XML stats") {
     std::string xml = "<icestats><source mount=\"/stream\"><listeners>5</listeners><bitrate>128</bitrate><title>Test</title></source></icestats>";
     StatsServer server(xml);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    scastd::Icecast2 ice("localhost", 18081, "", "");
+    CurlClient client;
+    scastd::Icecast2 ice("localhost", 18081, "", "", client);
     std::vector<scastd::Icecast2::StreamInfo> stats;
     std::string err;
     REQUIRE(ice.fetchStats(stats, err));


### PR DESCRIPTION
## Summary
- Replace standalone fetchUrl with CurlClient class for easier mocking
- Inject CurlClient into Icecast2 and update scastd call site
- Adjust build scripts, tests, and documentation for new CurlClient

## Testing
- `autoreconf -i`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689818af656c832bb39f6fd14d517376