### PR TITLE
Add basic gettext-based i18n and English translations

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -1,0 +1,184 @@
+# English translations for PACKAGE package.
+# Copyright (C) 2025 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-10 04:12+0000\n"
+"PO-Revision-Date: 2025-08-10 04:12+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=ASCII\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/HttpServer.cpp:111
+msgid "Not Found"
+msgstr "Not Found"
+
+#: src/scastd.cpp:60
+#, c-format
+msgid "Webdata: %s\n"
+msgstr "Webdata: %s\n"
+
+#: src/scastd.cpp:132
+#, c-format
+msgid "Cannot open logfile %s\n"
+msgstr "Cannot open logfile %s\n"
+
+#: src/scastd.cpp:157
+msgid "Caught SIGUSR1 - Resuming\n"
+msgstr "Caught SIGUSR1 - Resuming\n"
+
+#: src/scastd.cpp:161
+msgid "Caught SIGUSR1 - Pausing\n"
+msgstr "Caught SIGUSR1 - Pausing\n"
+
+#: src/scastd.cpp:168
+msgid "Caught SIGUSR2 - Exiting\n"
+msgstr "Caught SIGUSR2 - Exiting\n"
+
+#: src/scastd.cpp:175
+msgid "Caught SIGTERM - Exiting\n"
+msgstr "Caught SIGTERM - Exiting\n"
+
+#: src/scastd.cpp:181
+msgid "Caught SIGINT - Exiting\n"
+msgstr "Caught SIGINT - Exiting\n"
+
+#: src/scastd.cpp:187
+msgid "Caught SIGHUP - Reloading config\n"
+msgstr "Caught SIGHUP - Reloading config\n"
+
+#: src/scastd.cpp:229
+#, c-format
+msgid "Cannot load config file %s\n"
+msgstr "Cannot load config file %s\n"
+
+#: src/scastd.cpp:236
+#, c-format
+msgid "Failed to start HTTP server on port %d\n"
+msgstr "Failed to start HTTP server on port %d\n"
+
+#: src/scastd.cpp:260
+#, c-format
+msgid ""
+"Unknown DatabaseType '%s'. Supported values are mysql, mariadb, postgres. "
+"Falling back to default 'mysql'.\n"
+msgstr ""
+"Unknown DatabaseType '%s'. Supported values are mysql, mariadb, postgres. "
+"Falling back to default 'mysql'.\n"
+
+#: src/scastd.cpp:266
+#, c-format
+msgid "Detaching from console...\n"
+msgstr "Detaching from console...\n"
+
+#: src/scastd.cpp:276
+#, c-format
+msgid "Cannot install handler for SIGUSR1\n"
+msgstr "Cannot install handler for SIGUSR1\n"
+
+#: src/scastd.cpp:280
+#, c-format
+msgid "Cannot install handler for SIGUSR2\n"
+msgstr "Cannot install handler for SIGUSR2\n"
+
+#: src/scastd.cpp:284
+#, c-format
+msgid "Cannot install handler for SIGTERM\n"
+msgstr "Cannot install handler for SIGTERM\n"
+
+#: src/scastd.cpp:288
+#, c-format
+msgid "Cannot install handler for SIGINT\n"
+msgstr "Cannot install handler for SIGINT\n"
+
+#: src/scastd.cpp:292
+#, c-format
+msgid "Cannot install handler for SIGHUP\n"
+msgstr "Cannot install handler for SIGHUP\n"
+
+#: src/scastd.cpp:301
+#, c-format
+msgid "We must have an entry in the scastd_runtime table..exiting.\n"
+msgstr "We must have an entry in the scastd_runtime table..exiting.\n"
+
+#: src/scastd.cpp:308
+msgid "SCASTD starting...\n"
+msgstr "SCASTD starting...\n"
+
+#: src/scastd.cpp:346
+msgid "Unknown DatabaseType. Falling back to mysql\n"
+msgstr "Unknown DatabaseType. Falling back to mysql\n"
+
+#: src/scastd.cpp:364
+msgid "Configuration reloaded\n"
+msgstr "Configuration reloaded\n"
+
+#: src/scastd.cpp:366
+msgid "Failed to reload config\n"
+msgstr "Failed to reload config\n"
+
+#: src/scastd.cpp:370
+msgid "Exiting...\n"
+msgstr "Exiting...\n"
+
+#: src/scastd.cpp:397
+#, c-format
+msgid "Connecting to server %s at port %d\n"
+msgstr "Connecting to server %s at port %d\n"
+
+#: src/scastd.cpp:404
+#, c-format
+msgid "Bad password (%s/%s)\n"
+msgstr "Bad password (%s/%s)\n"
+
+#: src/scastd.cpp:412
+msgid "Bad parse!"
+msgstr "Bad parse!"
+
+#: src/scastd.cpp:417
+msgid "Empty Document!"
+msgstr "Empty Document!"
+
+#: src/scastd.cpp:478
+#, c-format
+msgid "Bad data from %s\n"
+msgstr "Bad data from %s\n"
+
+#: src/scastd.cpp:483
+#, c-format
+msgid "Failed to fetch data from %s\n"
+msgstr "Failed to fetch data from %s\n"
+
+#: src/scastd.cpp:491
+#, c-format
+msgid "Sleeping for %d seconds\n"
+msgstr "Sleeping for %d seconds\n"
+
+#: src/db/MariaDBDatabase.cpp:48 src/db/MySQLDatabase.cpp:48
+#: src/db/PostgresDatabase.cpp:54
+msgid "Failed to connect to database: "
+msgstr "Failed to connect to database: "
+
+#: src/db/MariaDBDatabase.cpp:60 src/db/MySQLDatabase.cpp:60
+msgid "Misformed query ("
+msgstr "Misformed query ("
+
+#: src/db/MariaDBDatabase.cpp:60 src/db/MySQLDatabase.cpp:60
+msgid ""
+")\n"
+"Error: "
+msgstr ""
+")\n"
+"Error: "
+
+#: src/db/PostgresDatabase.cpp:68
+msgid "Query failed: "
+msgstr "Query failed: "

--- a/po/scastd.pot
+++ b/po/scastd.pot
@@ -1,0 +1,180 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-10 04:12+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/HttpServer.cpp:111
+msgid "Not Found"
+msgstr ""
+
+#: src/scastd.cpp:60
+#, c-format
+msgid "Webdata: %s\n"
+msgstr ""
+
+#: src/scastd.cpp:132
+#, c-format
+msgid "Cannot open logfile %s\n"
+msgstr ""
+
+#: src/scastd.cpp:157
+msgid "Caught SIGUSR1 - Resuming\n"
+msgstr ""
+
+#: src/scastd.cpp:161
+msgid "Caught SIGUSR1 - Pausing\n"
+msgstr ""
+
+#: src/scastd.cpp:168
+msgid "Caught SIGUSR2 - Exiting\n"
+msgstr ""
+
+#: src/scastd.cpp:175
+msgid "Caught SIGTERM - Exiting\n"
+msgstr ""
+
+#: src/scastd.cpp:181
+msgid "Caught SIGINT - Exiting\n"
+msgstr ""
+
+#: src/scastd.cpp:187
+msgid "Caught SIGHUP - Reloading config\n"
+msgstr ""
+
+#: src/scastd.cpp:229
+#, c-format
+msgid "Cannot load config file %s\n"
+msgstr ""
+
+#: src/scastd.cpp:236
+#, c-format
+msgid "Failed to start HTTP server on port %d\n"
+msgstr ""
+
+#: src/scastd.cpp:260
+#, c-format
+msgid ""
+"Unknown DatabaseType '%s'. Supported values are mysql, mariadb, postgres. "
+"Falling back to default 'mysql'.\n"
+msgstr ""
+
+#: src/scastd.cpp:266
+#, c-format
+msgid "Detaching from console...\n"
+msgstr ""
+
+#: src/scastd.cpp:276
+#, c-format
+msgid "Cannot install handler for SIGUSR1\n"
+msgstr ""
+
+#: src/scastd.cpp:280
+#, c-format
+msgid "Cannot install handler for SIGUSR2\n"
+msgstr ""
+
+#: src/scastd.cpp:284
+#, c-format
+msgid "Cannot install handler for SIGTERM\n"
+msgstr ""
+
+#: src/scastd.cpp:288
+#, c-format
+msgid "Cannot install handler for SIGINT\n"
+msgstr ""
+
+#: src/scastd.cpp:292
+#, c-format
+msgid "Cannot install handler for SIGHUP\n"
+msgstr ""
+
+#: src/scastd.cpp:301
+#, c-format
+msgid "We must have an entry in the scastd_runtime table..exiting.\n"
+msgstr ""
+
+#: src/scastd.cpp:308
+msgid "SCASTD starting...\n"
+msgstr ""
+
+#: src/scastd.cpp:346
+msgid "Unknown DatabaseType. Falling back to mysql\n"
+msgstr ""
+
+#: src/scastd.cpp:364
+msgid "Configuration reloaded\n"
+msgstr ""
+
+#: src/scastd.cpp:366
+msgid "Failed to reload config\n"
+msgstr ""
+
+#: src/scastd.cpp:370
+msgid "Exiting...\n"
+msgstr ""
+
+#: src/scastd.cpp:397
+#, c-format
+msgid "Connecting to server %s at port %d\n"
+msgstr ""
+
+#: src/scastd.cpp:404
+#, c-format
+msgid "Bad password (%s/%s)\n"
+msgstr ""
+
+#: src/scastd.cpp:412
+msgid "Bad parse!"
+msgstr ""
+
+#: src/scastd.cpp:417
+msgid "Empty Document!"
+msgstr ""
+
+#: src/scastd.cpp:478
+#, c-format
+msgid "Bad data from %s\n"
+msgstr ""
+
+#: src/scastd.cpp:483
+#, c-format
+msgid "Failed to fetch data from %s\n"
+msgstr ""
+
+#: src/scastd.cpp:491
+#, c-format
+msgid "Sleeping for %d seconds\n"
+msgstr ""
+
+#: src/db/MariaDBDatabase.cpp:48 src/db/MySQLDatabase.cpp:48
+#: src/db/PostgresDatabase.cpp:54
+msgid "Failed to connect to database: "
+msgstr ""
+
+#: src/db/MariaDBDatabase.cpp:60 src/db/MySQLDatabase.cpp:60
+msgid "Misformed query ("
+msgstr ""
+
+#: src/db/MariaDBDatabase.cpp:60 src/db/MySQLDatabase.cpp:60
+msgid ""
+")\n"
+"Error: "
+msgstr ""
+
+#: src/db/PostgresDatabase.cpp:68
+msgid "Query failed: "
+msgstr ""

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -20,6 +20,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 */
 #include "HttpServer.h"
+#include "i18n.h"
 
 #include <cstring>
 #include <csignal>
@@ -107,9 +108,9 @@ MHD_Result HttpServer::handleRequest(void *cls,
         page = kXmlResponse;
         content_type = "application/xml";
     } else {
-        static const char not_found[] = "Not Found";
+        const char *not_found = _("Not Found");
         struct MHD_Response *response = MHD_create_response_from_buffer(
-            sizeof(not_found) - 1, (void *)not_found, MHD_RESPMEM_PERSISTENT);
+            std::strlen(not_found), (void *)not_found, MHD_RESPMEM_PERSISTENT);
         MHD_add_response_header(response, "Content-Type", "text/plain");
         int ret = MHD_queue_response(connection, MHD_HTTP_NOT_FOUND, response);
         MHD_destroy_response(response);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,6 +5,7 @@ scastd_SOURCES = \
     CurlClient.cpp \
     HttpServer.cpp \
     UrlParser.cpp \
+    i18n.cpp \
     icecast2.cpp \
     db/MySQLDatabase.cpp \
     db/MariaDBDatabase.cpp \

--- a/src/db/MariaDBDatabase.cpp
+++ b/src/db/MariaDBDatabase.cpp
@@ -1,6 +1,29 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #include "MariaDBDatabase.h"
 #include <iostream>
 #include <cstring>
+#include "i18n.h"
 
 MariaDBDatabase::MariaDBDatabase() : pResult(nullptr) {
     mysql_init(&mySQL);
@@ -22,7 +45,7 @@ bool MariaDBDatabase::connect(const std::string &username,
     mysql_options(&mySQL, MYSQL_READ_DEFAULT_GROUP, "scastd");
     (void)sslmode;
     if (!mysql_real_connect(&mySQL, host.c_str(), username.c_str(), password.c_str(), dbname.c_str(), port, NULL, 0)) {
-        std::cerr << "Failed to connect to database: " << mysql_error(&mySQL) << std::endl;
+        std::cerr << _("Failed to connect to database: ") << mysql_error(&mySQL) << std::endl;
         return false;
     }
     return true;
@@ -34,7 +57,7 @@ bool MariaDBDatabase::query(const std::string &queryStr) {
         pResult = nullptr;
     }
     if (mysql_query(&mySQL, queryStr.c_str()) != 0) {
-        std::cerr << "Misformed query (" << queryStr << ")\nError: " << mysql_error(&mySQL) << std::endl;
+        std::cerr << _("Misformed query (") << queryStr << _(")\nError: ") << mysql_error(&mySQL) << std::endl;
         return false;
     }
     pResult = mysql_store_result(&mySQL);

--- a/src/db/MySQLDatabase.cpp
+++ b/src/db/MySQLDatabase.cpp
@@ -1,6 +1,29 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #include "MySQLDatabase.h"
 #include <iostream>
 #include <cstring>
+#include "i18n.h"
 
 MySQLDatabase::MySQLDatabase() : pResult(nullptr) {
     mysql_init(&mySQL);
@@ -22,7 +45,7 @@ bool MySQLDatabase::connect(const std::string &username,
     mysql_options(&mySQL, MYSQL_READ_DEFAULT_GROUP, "scastd");
     (void)sslmode;
     if (!mysql_real_connect(&mySQL, host.c_str(), username.c_str(), password.c_str(), dbname.c_str(), port, NULL, 0)) {
-        std::cerr << "Failed to connect to database: " << mysql_error(&mySQL) << std::endl;
+        std::cerr << _("Failed to connect to database: ") << mysql_error(&mySQL) << std::endl;
         return false;
     }
     return true;
@@ -34,7 +57,7 @@ bool MySQLDatabase::query(const std::string &queryStr) {
         pResult = nullptr;
     }
     if (mysql_query(&mySQL, queryStr.c_str()) != 0) {
-        std::cerr << "Misformed query (" << queryStr << ")\nError: " << mysql_error(&mySQL) << std::endl;
+        std::cerr << _("Misformed query (") << queryStr << _(")\nError: ") << mysql_error(&mySQL) << std::endl;
         return false;
     }
     pResult = mysql_store_result(&mySQL);

--- a/src/db/PostgresDatabase.cpp
+++ b/src/db/PostgresDatabase.cpp
@@ -1,5 +1,28 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #include "PostgresDatabase.h"
 #include <iostream>
+#include "i18n.h"
 
 PostgresDatabase::PostgresDatabase() : conn(nullptr), result(nullptr), currentRow(0) {}
 
@@ -28,7 +51,7 @@ bool PostgresDatabase::connect(const std::string &username,
     }
     conn = PQconnectdb(conninfo.c_str());
     if (PQstatus(conn) != CONNECTION_OK) {
-        std::cerr << "Failed to connect to database: " << PQerrorMessage(conn) << std::endl;
+        std::cerr << _("Failed to connect to database: ") << PQerrorMessage(conn) << std::endl;
         return false;
     }
     return true;
@@ -42,7 +65,7 @@ bool PostgresDatabase::query(const std::string &queryStr) {
     result = PQexec(conn, queryStr.c_str());
     ExecStatusType status = PQresultStatus(result);
     if (status != PGRES_TUPLES_OK && status != PGRES_COMMAND_OK) {
-        std::cerr << "Query failed: " << PQerrorMessage(conn) << std::endl;
+        std::cerr << _("Query failed: ") << PQerrorMessage(conn) << std::endl;
         return false;
     }
     currentRow = 0;

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -1,0 +1,30 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "i18n.h"
+#include <locale.h>
+
+void init_i18n() {
+    setlocale(LC_ALL, "");
+    bindtextdomain("scastd", LOCALE_DIR);
+    textdomain("scastd");
+}

--- a/src/i18n.h
+++ b/src/i18n.h
@@ -1,0 +1,34 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#ifndef I18N_H
+#define I18N_H
+
+#include <libintl.h>
+
+#define _(String) gettext(String)
+#define N_(String) (String)
+#define LOCALE_DIR "po"
+
+void init_i18n();
+
+#endif // I18N_H


### PR DESCRIPTION
## Summary
- introduce gettext-based i18n helpers and initialization
- wrap user-visible strings with translation macros across project
- provide English translation catalog and template

## Testing
- `./autogen.sh` *(fails: `aclocal` missing; installed automake and libtool)*
- `./configure`
- `make` *(fails: `fatal error: mariadb/mysql.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68981ade939c832b94e13e032396844e