### PR TITLE
Add Debian and macOS packaging helpers

### DIFF
--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -1,0 +1,31 @@
+# Packaging
+
+## Debian/Ubuntu
+
+The `packaging/debian` directory provides a helper script and systemd unit file.
+
+```bash
+./packaging/debian/build_deb.sh 1.0
+```
+
+The script compiles the project, stages the install tree and produces a `.deb` such as `scastd_1.0_amd64.deb`.
+Install the included `scastd.service` to `/etc/systemd/system` and enable it with:
+
+```bash
+sudo systemctl enable --now scastd
+```
+
+## macOS
+
+The `packaging/macos` directory includes a `build_pkg.sh` script and a launchd property list.
+
+```bash
+./packaging/macos/build_pkg.sh 1.0
+```
+
+This generates `scastd-1.0.pkg` using `pkgbuild`.
+Copy `org.scastd.daemon.plist` to `/Library/LaunchDaemons` and load it:
+
+```bash
+sudo launchctl load -w /Library/LaunchDaemons/org.scastd.daemon.plist
+```

--- a/packaging/debian/build_deb.sh
+++ b/packaging/debian/build_deb.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION=${1:-1.0}
+PREFIX=/usr/local
+BUILD_DIR=$(pwd)/deb_build
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+# Build and stage files
+./autogen.sh
+./configure --prefix="$PREFIX"
+make
+make DESTDIR="$BUILD_DIR" install
+
+# Control metadata
+mkdir -p "$BUILD_DIR/DEBIAN"
+cat > "$BUILD_DIR/DEBIAN/control" <<CTRL
+Package: scastd
+Version: ${VERSION}
+Section: net
+Priority: optional
+Architecture: $(dpkg --print-architecture)
+Depends: libcurl4, libmicrohttpd12, libmariadb3, libpq5
+Maintainer: unknown
+Description: Scast Daemon
+CTRL
+
+dpkg-deb --build "$BUILD_DIR" "scastd_${VERSION}_$(dpkg --print-architecture).deb"

--- a/packaging/debian/scastd.service
+++ b/packaging/debian/scastd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Scast Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/scastd -c /etc/scastd.conf
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/macos/build_pkg.sh
+++ b/packaging/macos/build_pkg.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION=${1:-1.0}
+PREFIX=/usr/local
+BUILD_DIR=$(pwd)/pkg_build
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+./autogen.sh
+./configure --prefix="$PREFIX"
+make
+make DESTDIR="$BUILD_DIR" install
+
+pkgbuild --root "$BUILD_DIR" \
+  --identifier org.scastd.pkg \
+  --version "$VERSION" \
+  --install-location / \
+  "scastd-${VERSION}.pkg"

--- a/packaging/macos/org.scastd.daemon.plist
+++ b/packaging/macos/org.scastd.daemon.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.scastd.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/scastd</string>
+    <string>-c</string>
+    <string>/usr/local/etc/scastd.conf</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/scastd.log</string>
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/scastd.err</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add helper scripts to build Debian `.deb` and macOS `.pkg`
- provide systemd and launchd service files for scastd
- document packaging workflows and daemon setup

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_689822741270832bba690c3cff6a466d