### PR TITLE
feat: versioned status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ publishing them over HTTP.  It polls an Icecast2 server for current
 listener information, stores the results in a database, and exposes a
 lightweight web service built with `libmicrohttpd`.  The HTTP server
 listens on port **8333** and serves JSON or XML status responses at
-`/status.json` and `/status.xml`.  Database backends for MariaDB/MySQL
+`/v1/status.json` and `/v1/status.xml` (unversioned paths remain for
+backward compatibility).  Database backends for MariaDB/MySQL
 and PostgreSQL are currently supported.
 
 Building
@@ -75,12 +76,19 @@ endpoint:
 
 ```
 ./src/scastd scastd.conf &
-curl http://localhost:8333/status.json
+curl http://localhost:8333/v1/status.json
 ```
 
 Send `SIGHUP` to the running process to reload `scastd.conf`. Updated
 settings such as the log directory or database credentials take effect
 without restarting.
+
+API Versioning
+--------------
+HTTP endpoints are namespaced by API version (e.g., `/v1/status.json`).
+Breaking changes will result in a new major version such as `/v2`. Older
+versions may continue to be served for a transition period, but
+unversioned paths are deprecated and may be removed in a future release.
 
 
 Troubleshooting

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -42,6 +42,7 @@ void handle_signal(int) {
 
 static const char kJsonResponse[] = "{\"status\":\"ok\"}";
 static const char kXmlResponse[] = "<status>ok</status>";
+static const char kApiVersion[] = "/v1";
 } // namespace
 
 HttpServer::HttpServer() : running_(false), daemon_(nullptr) {}
@@ -101,13 +102,19 @@ MHD_Result HttpServer::handleRequest(void *cls,
     const char *page = nullptr;
     const char *content_type = nullptr;
 
+    if (std::strncmp(url, kApiVersion, std::strlen(kApiVersion)) == 0) {
+        url += std::strlen(kApiVersion);
+    }
+
     if (std::strcmp(url, "/status.json") == 0) {
         page = kJsonResponse;
         content_type = "application/json";
     } else if (std::strcmp(url, "/status.xml") == 0) {
         page = kXmlResponse;
         content_type = "application/xml";
-    } else {
+    }
+
+    if (!page) {
         const char *not_found = _("Not Found");
         struct MHD_Response *response = MHD_create_response_from_buffer(
             std::strlen(not_found), (void *)not_found, MHD_RESPMEM_PERSISTENT);

--- a/tests/test_http.cpp
+++ b/tests/test_http.cpp
@@ -1,3 +1,24 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
 #include "catch.hpp"
 #include "HttpServer.h"
 #include <curl/curl.h>
@@ -25,7 +46,7 @@ TEST_CASE("HTTP server responds with status") {
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buffer);
 
-    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:18080/status.json");
+    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:18080/v1/status.json");
     CURLcode res = curl_easy_perform(curl);
     REQUIRE(res == CURLE_OK);
     long code = 0;
@@ -37,7 +58,7 @@ TEST_CASE("HTTP server responds with status") {
     REQUIRE(buffer == "{\"status\":\"ok\"}");
 
     buffer.clear();
-    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:18080/status.xml");
+    curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:18080/v1/status.xml");
     res = curl_easy_perform(curl);
     REQUIRE(res == CURLE_OK);
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);


### PR DESCRIPTION
## Summary
- serve status responses under versioned paths such as `/v1/status.json`
- support legacy unversioned paths for backward compatibility
- document API versioning policy and usage in README

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6898292b2e4c832baf86f7f83ec5b772