### PR TITLE
Add systemd service and installation docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,6 +68,29 @@ Then build and run the tests:
 make && make check
 ```
 
+Systemd service
+~~~~~~~~~~~~~~~~
+Install the provided `scastd.service` to run the daemon under systemd:
+
+1. Copy the file into `/etc/systemd/system/`:
+
+   ```
+   sudo cp scastd.service /etc/systemd/system/
+   ```
+
+2. Create a dedicated user for the service if needed:
+
+   ```
+   sudo useradd --system --no-create-home --shell /usr/sbin/nologin scastd
+   ```
+
+3. Reload systemd and enable the service:
+
+   ```
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now scastd.service
+   ```
+
 Basic Installation
 ==================
 

--- a/scastd.service
+++ b/scastd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Scast Daemon
+After=network.target
+
+[Service]
+Type=simple
+User=scastd
+ExecStart=/usr/local/bin/scastd -c /etc/scastd.conf
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add `scastd.service` systemd unit running as the `scastd` user and restarting on failure
- document how to install and enable the service under systemd

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68982ad6dc60832bb1034dded624ea9a