### PR TITLE
Add uptime endpoint with optional auth

### DIFF
--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -22,7 +22,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <microhttpd.h>
+#include <string>
 
 namespace scastd {
 
@@ -31,7 +33,7 @@ public:
     HttpServer();
     ~HttpServer();
 
-    bool start(int port = 8333);
+    bool start(int port = 8333, const std::string &user = "", const std::string &pass = "");
     void stop();
 
 private:
@@ -46,6 +48,9 @@ private:
 
     std::atomic<bool> running_;
     struct MHD_Daemon *daemon_;
+    std::chrono::steady_clock::time_point start_time_;
+    std::string username_;
+    std::string password_;
 };
 
 } // namespace scastd

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -172,8 +172,10 @@ int main(int argc, char **argv)
         }
         bool httpEnabled = cfg.Get("http_enabled", true);
         int httpPort = cfg.Get("http_port", 8333);
+        std::string httpUser = cfg.Get("http_username", "");
+        std::string httpPass = cfg.Get("http_password", "");
         if (httpEnabled) {
-                if (!httpServer.start(httpPort)) {
+                if (!httpServer.start(httpPort, httpUser, httpPass)) {
                         fprintf(stderr, _("Failed to start HTTP server on port %d\n"), httpPort);
                 }
         }


### PR DESCRIPTION
## Summary
- add `/v1/uptime` endpoint reporting server uptime
- support optional basic auth via new HttpServer parameters and config
- test uptime endpoint and authentication

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68982c924f94832ba8faaffececedcce