### PR TITLE
Add HTTP API and database insertion example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# HTTP API and Database Insertion Example
+
+This directory contains a small Python script that fetches JSON data from a public HTTP API and stores it in a SQLite database.
+
+## Usage
+
+Run the script with Python 3:
+
+```bash
+python3 api_db_example.py
+```
+
+The script downloads a sample post from `jsonplaceholder.typicode.com` and inserts it into `example.db`. After running, it prints the inserted row.

--- a/examples/api_db_example.py
+++ b/examples/api_db_example.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Fetch JSON data from an HTTP API and insert it into a SQLite database."""
+
+import json
+import sqlite3
+import urllib.request
+
+API_URL = "https://jsonplaceholder.typicode.com/posts/1"
+DB_PATH = "example.db"
+
+
+def main() -> None:
+    # Retrieve JSON payload from the HTTP API
+    with urllib.request.urlopen(API_URL) as response:
+        payload = json.load(response)
+
+    # Create or open the database and ensure the table exists
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY, title TEXT, body TEXT)"
+    )
+
+    # Insert the retrieved payload into the database
+    cur.execute(
+        "INSERT OR REPLACE INTO posts (id, title, body) VALUES (:id, :title, :body)",
+        payload,
+    )
+    conn.commit()
+
+    # Verify insertion
+    row = cur.execute("SELECT id, title FROM posts WHERE id = ?", (payload["id"],)).fetchone()
+    print(f"Inserted row: {row}")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python example that retrieves JSON over HTTP and stores it in a SQLite database
- document how to run the example

## Testing
- `./autogen.sh`
- `./configure`
- `make` *(fails: mariadb/mysql.h: No such file or directory)*
- `make check` *(fails: mariadb/mysql.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68982e6539dc832b9d39352d7650fb0c