### PR TITLE
Add install target for config and DB setup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,6 +68,17 @@ Then build and run the tests:
 make && make check
 ```
 
+Configuration and database setup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Install the default configuration and initialize the SQLite database:
+
+```
+sudo make install
+```
+
+This creates `/etc/scastd/` (mode `755`), copies `scastd.conf`, and
+initializes `scastd.db` with permissions set to `640`.
+
 Systemd service
 ~~~~~~~~~~~~~~~~
 Install the provided `scastd.service` to run the daemon under systemd:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,8 @@
 SUBDIRS = src tests
+
+# Installation of configuration and SQLite database
+install-data-local:
+	$(INSTALL) -d -m 755 $(DESTDIR)/etc/scastd
+	$(INSTALL_DATA) -m 640 $(srcdir)/scastd.conf $(DESTDIR)/etc/scastd/scastd.conf
+	sqlite3 $(DESTDIR)/etc/scastd/scastd.db < $(srcdir)/src/sqlite.sql
+	chmod 640 $(DESTDIR)/etc/scastd/scastd.db


### PR DESCRIPTION
## Summary
- Add `install-data-local` rule that creates `/etc/scastd`, installs `scastd.conf`, and initializes `scastd.db` with secure permissions
- Document configuration installation and database initialization in `INSTALL.md`

## Testing
- `./autogen.sh`
- `./configure`
- `make check`
- `make install DESTDIR=$(pwd)/dest`


------
https://chatgpt.com/codex/tasks/task_e_68983470e760832b90d557cf3d24cecf