### PR TITLE
feat: add database dump option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,9 +25,24 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 int main(int argc, char **argv) {
     std::string configPath = "scastd.conf";
-    if (argc > 1) {
-        configPath = argv[1];
+    std::string dumpDir = "/tmp";
+    bool doDump = false;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--dump") {
+            doDump = true;
+        } else if (arg == "--dump-dir" && i + 1 < argc) {
+            dumpDir = argv[++i];
+        } else {
+            configPath = arg;
+        }
     }
+
+    if (doDump) {
+        return scastd::dumpDatabase(configPath, dumpDir);
+    }
+
     return scastd::run(configPath);
 }
 

--- a/src/scastd.h
+++ b/src/scastd.h
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 namespace scastd {
 int run(const std::string &configPath);
+int dumpDatabase(const std::string &configPath, const std::string &dumpDir);
 }
 
 #endif // SCASTD_H


### PR DESCRIPTION
## Summary
- support `--dump` and `--dump-dir` CLI options
- allow dumping MySQL, MariaDB, PostgreSQL, or SQLite databases to a chosen directory
- log the result of database dump operations

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689836025ba0832b965c9ca7d350bbb3