### PR TITLE
Replace global logging with configurable Logger

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,9 +45,6 @@ PKG_CHECK_MODULES([OPENSSL], [openssl], [], [AC_MSG_ERROR([OpenSSL library not f
 CXXFLAGS="$CXXFLAGS $OPENSSL_CFLAGS"
 LIBS="$LIBS $OPENSSL_LIBS"
 
-PKG_CHECK_MODULES([SPDLOG], [spdlog], [], [AC_MSG_ERROR([spdlog library not found; install libspdlog-dev.])])
-CXXFLAGS="$CXXFLAGS $SPDLOG_CFLAGS"
-LIBS="$LIBS $SPDLOG_LIBS"
 
 dnl Make substitutions
 AC_SUBST(CXXFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,7 @@ scastd_SOURCES = \
     UrlParser.cpp \
     i18n.cpp \
     icecast2.cpp \
+    logger.cpp \
     db/MySQLDatabase.cpp \
     db/MariaDBDatabase.cpp \
     db/PostgresDatabase.cpp \

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,81 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "logger.h"
+
+#include <filesystem>
+#include <iostream>
+
+Logger::Logger(const std::string &directory, bool consoleOut)
+    : logDir(directory), console(consoleOut) {
+    openStreams();
+}
+
+void Logger::setLogDir(const std::string &directory) {
+    std::lock_guard<std::mutex> lock(mtx);
+    logDir = directory;
+    openStreams();
+}
+
+void Logger::setConsoleOutput(bool enable) {
+    std::lock_guard<std::mutex> lock(mtx);
+    console = enable;
+}
+
+void Logger::logAccess(const std::string &message) {
+    write(accessStream, message, false);
+}
+
+void Logger::logError(const std::string &message) {
+    write(errorStream, message, true);
+}
+
+void Logger::logDebug(const std::string &message) {
+    write(debugStream, message, false);
+}
+
+void Logger::openStreams() {
+    if (logDir.empty())
+        logDir = ".";
+    std::filesystem::create_directories(logDir);
+    if (accessStream.is_open()) accessStream.close();
+    if (errorStream.is_open()) errorStream.close();
+    if (debugStream.is_open()) debugStream.close();
+    accessStream.open(logDir + "/access.log", std::ios::app);
+    errorStream.open(logDir + "/error.log", std::ios::app);
+    debugStream.open(logDir + "/debug.log", std::ios::app);
+}
+
+void Logger::write(std::ofstream &stream, const std::string &message, bool err) {
+    std::lock_guard<std::mutex> lock(mtx);
+    std::string msg = message;
+    if (!msg.empty() && msg.back() != '\n')
+        msg.push_back('\n');
+    stream << msg;
+    stream.flush();
+    if (console) {
+        if (err)
+            std::cerr << msg;
+        else
+            std::cout << msg;
+    }
+}

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,0 +1,55 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <string>
+#include <fstream>
+#include <mutex>
+
+class Logger {
+public:
+    enum class Level { Access, Error, Debug };
+
+    explicit Logger(const std::string &directory = ".", bool console = false);
+
+    void setLogDir(const std::string &directory);
+    void setConsoleOutput(bool enable);
+
+    void logAccess(const std::string &message);
+    void logError(const std::string &message);
+    void logDebug(const std::string &message);
+
+private:
+    std::string logDir;
+    bool console;
+    std::ofstream accessStream;
+    std::ofstream errorStream;
+    std::ofstream debugStream;
+    std::mutex mtx;
+
+    void write(std::ofstream &stream, const std::string &message, bool err);
+    void openStreams();
+};
+
+#endif // LOGGER_H


### PR DESCRIPTION
## Summary
- add GPL-licensed `Logger` supporting access, error, and debug log files with optional console output
- switch daemon to new `Logger`, removing old global logging functions and spdlog dependency
- update build scripts to compile `logger.cpp`

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68983aa1f6b8832b8052fcc34ac0837e