### PR TITLE
docs: document logging and syslog options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,24 @@ password secret
 log_dir ./logs
 log_max_size 1048576
 log_retention 5
+access_log access.log
+error_log error.log
+debug_log debug.log
+debug_level 1
+syslog_enabled false
+syslog_host localhost
+syslog_port 514
+syslog_protocol udp
 ```
+
+The log settings allow fine-grained control over where messages are
+written. `access_log`, `error_log`, and `debug_log` may be absolute
+paths or names relative to `log_dir` and default to `access.log`,
+`error.log`, and `debug.log` respectively. `debug_level` sets the
+verbosity for the debug log from 1 (least verbose) to 4 (most verbose).
+When `syslog_enabled` is `true`, log messages are also forwarded to a
+remote syslog server defined by `syslog_host`, `syslog_port` (default
+`514`), and `syslog_protocol` (`udp` or `tcp`).
 
 For security, make the configuration file readable only by your user:
 

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,0 +1,21 @@
+# Logging Configuration
+
+Scastd can write access, error, and debug information to separate log
+files and optionally forward messages to a remote syslog server. The
+following configuration keys control logging behaviour. Paths may be
+absolute or relative to `log_dir`.
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `log_dir` | `./logs` | Directory where log files are stored. |
+| `access_log` | `access.log` | File receiving HTTP access entries. |
+| `error_log` | `error.log` | File receiving error messages. |
+| `debug_log` | `debug.log` | File receiving debug output. |
+| `debug_level` | `1` | Debug verbosity level (`1`–`4`). |
+| `syslog_enabled` | `false` | Enable forwarding to a syslog server. |
+| `syslog_host` | `localhost` | Hostname or IP of the syslog server. |
+| `syslog_port` | `514` | Syslog server port. |
+| `syslog_protocol` | `udp` | Transport protocol (`udp` or `tcp`). |
+
+When syslog forwarding is enabled, messages are still written to the
+local log files in addition to being sent to the remote server.

--- a/scastd.conf
+++ b/scastd.conf
@@ -17,6 +17,17 @@ log_dir ./logs
 log_max_size 1048576
 # Number of rotated log files to keep
 log_retention 5
+# Specific log file paths (relative to log_dir or absolute)
+access_log access.log
+error_log error.log
+debug_log debug.log
+# Debug verbosity level (1-4)
+debug_level 1
+# Optional syslog output
+syslog_enabled false
+syslog_host localhost
+syslog_port 514
+syslog_protocol udp
 
 # HTTP server configuration
 # Enable or disable the built-in HTTP status server (default: true)

--- a/scastd_pg.conf
+++ b/scastd_pg.conf
@@ -11,3 +11,16 @@ host 127.0.0.1
 port 5432
 dbname scastd
 sslmode require
+
+# Logging configuration
+log_dir ./logs
+log_max_size 1048576
+log_retention 5
+access_log access.log
+error_log error.log
+debug_log debug.log
+debug_level 1
+syslog_enabled false
+syslog_host localhost
+syslog_port 514
+syslog_protocol udp


### PR DESCRIPTION
## Summary
- add access, error, debug log path settings, debug level, and syslog parameters to sample configs
- document new logging options in README and dedicated Logging.md

## Testing
- `./autogen.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6898ab32af7c832bb5f8538285588750