### PR TITLE
Add logging and syslog getters

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,3 +1,25 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #include "Config.h"
 #include <fstream>
 #include <sstream>
@@ -107,4 +129,52 @@ bool Config::Get(const std::string &key, bool def) const {
         }
     }
     return def;
+}
+
+static std::string combine_log_path(const std::string &dir, const std::string &path) {
+    if (!path.empty() && path[0] != '/') {
+        if (!dir.empty() && dir.back() == '/') {
+            return dir + path;
+        }
+        return dir + "/" + path;
+    }
+    return path;
+}
+
+std::string Config::AccessLog() const {
+    std::string dir = Get("log_dir", "./logs");
+    std::string path = Get("access_log", "access.log");
+    return combine_log_path(dir, path);
+}
+
+std::string Config::ErrorLog() const {
+    std::string dir = Get("log_dir", "./logs");
+    std::string path = Get("error_log", "error.log");
+    return combine_log_path(dir, path);
+}
+
+std::string Config::DebugLog() const {
+    std::string dir = Get("log_dir", "./logs");
+    std::string path = Get("debug_log", "debug.log");
+    return combine_log_path(dir, path);
+}
+
+int Config::DebugLevel() const {
+    return Get("debug_level", 0);
+}
+
+bool Config::SyslogEnabled() const {
+    return Get("syslog_enabled", false);
+}
+
+std::string Config::SyslogHost() const {
+    return Get("syslog_host", "localhost");
+}
+
+int Config::SyslogPort() const {
+    return Get("syslog_port", 514);
+}
+
+std::string Config::SyslogProtocol() const {
+    return Get("syslog_protocol", "udp");
 }

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,3 +1,25 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #ifndef CONFIG_H
 #define CONFIG_H
 
@@ -13,6 +35,16 @@ public:
     }
     int Get(const std::string &key, int def) const;
     bool Get(const std::string &key, bool def) const;
+
+    std::string AccessLog() const;
+    std::string ErrorLog() const;
+    std::string DebugLog() const;
+    int DebugLevel() const;
+    bool SyslogEnabled() const;
+    std::string SyslogHost() const;
+    int SyslogPort() const;
+    std::string SyslogProtocol() const;
+
 private:
     std::map<std::string, std::string> values;
 };

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,3 +1,25 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #include "catch.hpp"
 #include "Config.h"
 #include <fstream>
@@ -65,4 +87,52 @@ TEST_CASE("Environment and secret overrides") {
     std::remove(ufile);
     std::remove(pfile);
     std::remove(cfg);
+}
+
+TEST_CASE("Logging configuration defaults") {
+    const char* fname = "log.conf";
+    std::ofstream out(fname);
+    out << "log_dir logs\n";
+    out.close();
+
+    Config cfg;
+    REQUIRE(cfg.Load(fname));
+    REQUIRE(cfg.AccessLog() == std::string("logs/access.log"));
+    REQUIRE(cfg.ErrorLog() == std::string("logs/error.log"));
+    REQUIRE(cfg.DebugLog() == std::string("logs/debug.log"));
+    REQUIRE(cfg.DebugLevel() == 0);
+    REQUIRE(cfg.SyslogEnabled() == false);
+    REQUIRE(cfg.SyslogHost() == std::string("localhost"));
+    REQUIRE(cfg.SyslogPort() == 514);
+    REQUIRE(cfg.SyslogProtocol() == std::string("udp"));
+
+    std::remove(fname);
+}
+
+TEST_CASE("Logging configuration overrides") {
+    const char* fname = "log_override.conf";
+    std::ofstream out(fname);
+    out << "log_dir logs\n";
+    out << "access_log /tmp/access.log\n";
+    out << "error_log err.log\n";
+    out << "debug_log dbg.log\n";
+    out << "debug_level 2\n";
+    out << "syslog_enabled true\n";
+    out << "syslog_host remote\n";
+    out << "syslog_port 1514\n";
+    out << "syslog_protocol tcp\n";
+    out.close();
+
+    Config cfg;
+    REQUIRE(cfg.Load(fname));
+    REQUIRE(cfg.AccessLog() == std::string("/tmp/access.log"));
+    REQUIRE(cfg.ErrorLog() == std::string("logs/err.log"));
+    REQUIRE(cfg.DebugLog() == std::string("logs/dbg.log"));
+    REQUIRE(cfg.DebugLevel() == 2);
+    REQUIRE(cfg.SyslogEnabled() == true);
+    REQUIRE(cfg.SyslogHost() == std::string("remote"));
+    REQUIRE(cfg.SyslogPort() == 1514);
+    REQUIRE(cfg.SyslogProtocol() == std::string("tcp"));
+
+    std::remove(fname);
 }


### PR DESCRIPTION
## Summary
- add getters for log file paths, debug level, and syslog settings with sensible defaults
- cover new configuration keys and defaults with unit tests

## Testing
- `make check` (fails: No rule to make target 'check')
- `g++ -std=c++11 -Isrc -Itests tests/test_main.cpp tests/test_config.cpp src/Config.cpp -o config_test && ./config_test`


------
https://chatgpt.com/codex/tasks/task_e_6898b03bf6b4832badb7b091bcca657a