### PR TITLE
Add configurable logging and debug instrumentation

### DIFF
--- a/src/db/MariaDBDatabase.h
+++ b/src/db/MariaDBDatabase.h
@@ -1,8 +1,30 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #ifndef MARIADBDATABASE_H
 #define MARIADBDATABASE_H
 
 #include "IDatabase.h"
-#include <mariadb/mysql.h>
+#include <mysql/mysql.h>
 
 class MariaDBDatabase : public IDatabase {
 public:

--- a/src/db/MySQLDatabase.cpp
+++ b/src/db/MySQLDatabase.cpp
@@ -24,6 +24,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <iostream>
 #include <cstring>
 #include "i18n.h"
+#include "logger.h"
+
+namespace scastd { extern Logger logger; }
 
 MySQLDatabase::MySQLDatabase() : pResult(nullptr) {
     mysql_init(&mySQL);
@@ -45,9 +48,10 @@ bool MySQLDatabase::connect(const std::string &username,
     mysql_options(&mySQL, MYSQL_READ_DEFAULT_GROUP, "scastd");
     (void)sslmode;
     if (!mysql_real_connect(&mySQL, host.c_str(), username.c_str(), password.c_str(), dbname.c_str(), port, NULL, 0)) {
-        std::cerr << _("Failed to connect to database: ") << mysql_error(&mySQL) << std::endl;
+        scastd::logger.logError(std::string(_("Failed to connect to database: ")) + mysql_error(&mySQL));
         return false;
     }
+    scastd::logger.logDebug(std::string("MySQL connected to ") + host + ":" + std::to_string(port) + "/" + dbname);
     return true;
 }
 
@@ -56,8 +60,9 @@ bool MySQLDatabase::query(const std::string &queryStr) {
         mysql_free_result(pResult);
         pResult = nullptr;
     }
+    scastd::logger.logDebug(std::string("MySQL query: ") + queryStr);
     if (mysql_query(&mySQL, queryStr.c_str()) != 0) {
-        std::cerr << _("Misformed query (") << queryStr << _(")\nError: ") << mysql_error(&mySQL) << std::endl;
+        scastd::logger.logError(std::string(_("Misformed query (")) + queryStr + _(") Error: ") + mysql_error(&mySQL));
         return false;
     }
     pResult = mysql_store_result(&mySQL);

--- a/src/db/MySQLDatabase.h
+++ b/src/db/MySQLDatabase.h
@@ -1,8 +1,30 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
 #ifndef MYSQLDATABASE_H
 #define MYSQLDATABASE_H
 
 #include "IDatabase.h"
-#include <mariadb/mysql.h>
+#include <mysql/mysql.h>
 
 class MySQLDatabase : public IDatabase {
 public:


### PR DESCRIPTION
## Summary
- initialize logger with configurable file paths, debug level, console flag and syslog endpoint
- replace direct console output with logger calls and add detailed debug logging across core modules

## Testing
- `./configure`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6898b19e4bb0832b8d06395833c9cefa