### PR TITLE
Add runtime logging configuration flags

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,6 +79,11 @@ sudo make install
 This creates `/etc/scastd/` (mode `755`), copies `scastd.conf`, and
 initializes `scastd.db` with permissions set to `640`.
 
+When running the daemon manually, logging can be controlled without
+editing the configuration file by using command-line flags. Use
+`--logging=true|false` to enable or disable file logging and
+`--logpath=/path/to/logs` to specify an alternate log directory.
+
 Systemd service
 ~~~~~~~~~~~~~~~~
 Install the provided `scastd.service` to run the daemon under systemd:

--- a/README.md
+++ b/README.md
@@ -102,9 +102,16 @@ endpoint:
 curl http://localhost:8333/v1/status.json
 ```
 
-Send `SIGHUP` to the running process to reload `scastd.conf`. Updated
-settings such as the log directory or database credentials take effect
-without restarting.
+Optional flags control logging at startup:
+
+```
+./src/scastd --logging=false --logpath=/var/log/scastd scastd.conf &
+```
+
+`--logging` enables or disables file logging (default `true`), while
+`--logpath` overrides the log directory. Send `SIGHUP` to the running
+process to reload `scastd.conf`. Updated settings such as the log
+directory or database credentials take effect without restarting.
 
 API Versioning
 --------------

--- a/src/logger.h
+++ b/src/logger.h
@@ -35,6 +35,7 @@ public:
 
     void setLogDir(const std::string &directory);
     void setConsoleOutput(bool enable);
+    void setEnabled(bool enable);
 
     void logAccess(const std::string &message);
     void logError(const std::string &message);
@@ -43,6 +44,7 @@ public:
 private:
     std::string logDir;
     bool console;
+    bool enabled;
     std::ofstream accessStream;
     std::ofstream errorStream;
     std::ofstream debugStream;
@@ -50,6 +52,7 @@ private:
 
     void write(std::ofstream &stream, const std::string &message, bool err);
     void openStreams();
+    void closeStreams();
 };
 
 #endif // LOGGER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,11 +22,25 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "scastd.h"
 #include <string>
+#include <iostream>
+
+static void printUsage()
+{
+    std::cout << "Usage: scastd [options] [config]\n"
+              << "\nOptions:\n"
+              << "  --dump                 Dump the database and exit\n"
+              << "  --dump-dir DIR         Directory for database dump\n"
+              << "  --logging=true|false   Enable or disable file logging\n"
+              << "  --logpath=PATH         Override log directory\n"
+              << "  -h, --help             Show this help message\n";
+}
 
 int main(int argc, char **argv) {
     std::string configPath = "scastd.conf";
     std::string dumpDir = "/tmp";
     bool doDump = false;
+    bool loggingEnabled = true;
+    std::string logPath;
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
@@ -34,15 +48,23 @@ int main(int argc, char **argv) {
             doDump = true;
         } else if (arg == "--dump-dir" && i + 1 < argc) {
             dumpDir = argv[++i];
+        } else if (arg.rfind("--logging=", 0) == 0) {
+            std::string val = arg.substr(10);
+            loggingEnabled = !(val == "false" || val == "0");
+        } else if (arg.rfind("--logpath=", 0) == 0) {
+            logPath = arg.substr(10);
+        } else if (arg == "--help" || arg == "-h") {
+            printUsage();
+            return 0;
         } else {
             configPath = arg;
         }
     }
 
     if (doDump) {
-        return scastd::dumpDatabase(configPath, dumpDir);
+        return scastd::dumpDatabase(configPath, dumpDir, loggingEnabled, logPath);
     }
 
-    return scastd::run(configPath);
+    return scastd::run(configPath, loggingEnabled, logPath);
 }
 

--- a/src/scastd.h
+++ b/src/scastd.h
@@ -26,8 +26,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <string>
 
 namespace scastd {
-int run(const std::string &configPath);
-int dumpDatabase(const std::string &configPath, const std::string &dumpDir);
+int run(const std::string &configPath,
+        bool loggingEnabled = true,
+        const std::string &logPath = "");
+int dumpDatabase(const std::string &configPath,
+                 const std::string &dumpDir,
+                 bool loggingEnabled = true,
+                 const std::string &logPath = "");
 }
 
 #endif // SCASTD_H


### PR DESCRIPTION
## Summary
- add `--logging` and `--logpath` CLI flags to control file logging
- allow Logger to be disabled and set log directory at runtime
- document new flags in README and INSTALL

## Testing
- `./autogen.sh`
- `./configure`
- `make`
- `make check`
- `./src/scastd --help`


------
https://chatgpt.com/codex/tasks/task_e_6898a808fc88832b82886b0180b00119