### PR TITLE
Delay logger initialization until runtime configuration

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -32,10 +32,13 @@ public:
     enum class Level { Access, Error, Debug };
     enum class SyslogProto { UDP, TCP };
 
-    explicit Logger(const std::string &accessFile = "access.log",
+    explicit Logger(bool enabled = false,
+                    const std::string &accessFile = "access.log",
                     const std::string &errorFile = "error.log",
                     const std::string &debugFile = "debug.log",
                     bool console = false);
+
+    void setEnabled(bool enable);
 
     void setLogFiles(const std::string &accessFile,
                      const std::string &errorFile,
@@ -54,6 +57,7 @@ private:
     std::string errorPath;
     std::string debugPath;
     bool console;
+    bool enabled;
     std::ofstream accessStream;
     std::ofstream errorStream;
     std::ofstream debugStream;

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -55,7 +55,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 namespace scastd {
 
-Logger logger;
+Logger logger(false);
 int     paused = 0;
 int     exiting = 0;
 volatile sig_atomic_t reloadConfig = 0;
@@ -119,6 +119,7 @@ int dumpDatabase(const std::string &configPath, const std::string &dumpDir) {
                         Logger::SyslogProto::TCP : Logger::SyslogProto::UDP;
                 logger.setSyslog(cfg.SyslogHost(), cfg.SyslogPort(), proto);
         }
+        logger.setEnabled(true);
 
         std::string dbUser = cfg.Get("username", "");
         std::string dbPass = cfg.Get("password", "");
@@ -342,6 +343,7 @@ int run(const std::string &configPath)
                         Logger::SyslogProto::TCP : Logger::SyslogProto::UDP;
                 logger.setSyslog(cfg.SyslogHost(), cfg.SyslogPort(), proto);
         }
+        logger.setEnabled(true);
         bool httpEnabled = cfg.Get("http_enabled", true);
         int httpPort = cfg.Get("http_port", 8333);
         std::string httpUser = cfg.Get("http_username", "");


### PR DESCRIPTION
## Summary
- Add optional `enabled` flag to `Logger` and expose `setEnabled` to control log streams
- Instantiate global `Logger` disabled and enable only after configuration

## Testing
- `make check` *(fails: parallel-tests: error: required file './test-driver' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898bb7ef9c0832bb4934b9d836a3cf3