### PR TITLE
Add Certbot setup script and HTTPS documentation

### DIFF
--- a/docs/HTTPS.md
+++ b/docs/HTTPS.md
@@ -1,0 +1,22 @@
+# HTTPS with Let's Encrypt
+
+The `scripts/setup_certbot.sh` script installs [Certbot](https://certbot.eff.org/),
+obtains an initial TLS certificate, and configures automatic renewal.
+
+## Usage
+
+```bash
+sudo scripts/setup_certbot.sh -e admin@example.com -d example.com [-d www.example.com]
+```
+
+Run the script as `root` (or with `sudo`) so it can install packages and write
+to `/etc/letsencrypt/`. Supply one or more `-d`/`--domain` options and a single
+`-e`/`--email` address for Let's Encrypt registration.
+
+On macOS the script uses Homebrew to install Certbot and registers the renewal
+service with `brew services start certbot`.
+
+On Debian or Ubuntu systems, `apt` installs Certbot and a `systemd` timer is
+enabled via `systemctl enable --now certbot.timer`.
+
+Certificates and keys are stored under `/etc/letsencrypt/`.

--- a/scripts/setup_certbot.sh
+++ b/scripts/setup_certbot.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+usage() {
+  echo "Usage: $0 -e EMAIL -d DOMAIN [-d DOMAIN...]" >&2
+  exit 1
+}
+
+if [[ $EUID -ne 0 ]]; then
+  echo "This script must be run as root" >&2
+  exit 1
+fi
+
+EMAIL=""
+DOMAINS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -e|--email)
+      EMAIL="$2"
+      shift 2
+      ;;
+    -d|--domain)
+      DOMAINS+=("$2")
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[ -z "$EMAIL" || ${#DOMAINS[@]} -eq 0 ]]; then
+  usage
+fi
+
+if ! command -v certbot >/dev/null 2>&1; then
+  if [[ "$(uname)" == "Darwin" ]]; then
+    if ! command -v brew >/dev/null 2>&1; then
+      echo "Homebrew is required on macOS" >&2
+      exit 1
+    fi
+    brew update
+    brew install certbot
+  elif [[ -f /etc/debian_version ]]; then
+    apt-get update
+    apt-get install -y certbot
+  else
+    echo "Unsupported platform" >&2
+    exit 1
+  fi
+fi
+
+DOMAIN_ARGS=()
+for d in "${DOMAINS[@]}"; do
+  DOMAIN_ARGS+=("-d" "$d")
+done
+
+certbot certonly --standalone --agree-tos -m "$EMAIL" "${DOMAIN_ARGS[@]}" --non-interactive
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  brew services start certbot
+else
+  systemctl enable --now certbot.timer
+fi
+
+echo "Certificates stored under /etc/letsencrypt/"


### PR DESCRIPTION
## Summary
- add `scripts/setup_certbot.sh` to install Certbot, obtain initial certificates, and configure automatic renewal
- document HTTPS setup and required privileges in `docs/HTTPS.md`

## Testing
- `./autogen.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6898deeefaa8832bbe85fa0e01e68e02