### PR TITLE
Install Certbot helper and automate renewal

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -102,6 +102,22 @@ Install the provided `scastd.service` to run the daemon under systemd:
    sudo systemctl enable --now scastd.service
    ```
 
+Certificate management
+~~~~~~~~~~~~~~~~~~~~~~
+The script `setup_certbot.sh` is installed to `/usr/share/scastd/` and
+can be used to obtain Let's Encrypt certificates.  When installing the
+Debian package, set the `SCASD_CERT_EMAIL` and `SCASD_CERT_DOMAINS`
+environment variables to automatically invoke the script.  Otherwise you
+may run it manually:
+
+```
+sudo /usr/share/scastd/setup_certbot.sh -e admin@example.com -d example.com [-d www.example.com]
+```
+
+The script installs Certbot and enables automated renewal via
+`systemctl enable --now certbot.timer` on Linux or `brew services start
+certbot` on macOS.
+
 Basic Installation
 ==================
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = src tests
+SUBDIRS = src tests scripts
 
 # Installation of configuration and SQLite database
 install-data-local:

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,6 @@ dnl Make substitutions
 AC_SUBST(CXXFLAGS)
 AC_SUBST(LIBS)
 
-AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile scripts/Makefile])
 AC_OUTPUT
 

--- a/packaging/debian/build_deb.sh
+++ b/packaging/debian/build_deb.sh
@@ -22,9 +22,12 @@ Version: ${VERSION}
 Section: net
 Priority: optional
 Architecture: $(dpkg --print-architecture)
-Depends: libcurl4, libmicrohttpd12, libmariadb3, libpq5
+Depends: libcurl4, libmicrohttpd12, libmariadb3, libpq5, certbot
 Maintainer: unknown
 Description: Scast Daemon
 CTRL
+
+cp packaging/debian/postinst "$BUILD_DIR/DEBIAN/postinst"
+chmod 755 "$BUILD_DIR/DEBIAN/postinst"
 
 dpkg-deb --build "$BUILD_DIR" "scastd_${VERSION}_$(dpkg --print-architecture).deb"

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "configure" ]; then
+    if [ -x /usr/share/scastd/setup_certbot.sh ]; then
+        if [ -n "$SCASD_CERT_EMAIL" ] && [ -n "$SCASD_CERT_DOMAINS" ]; then
+            DOMAINS=""
+            for d in $(echo "$SCASD_CERT_DOMAINS" | tr ',' ' '); do
+                DOMAINS="$DOMAINS -d $d"
+            done
+            /usr/share/scastd/setup_certbot.sh -e "$SCASD_CERT_EMAIL" $DOMAINS || true
+        else
+            echo "Run /usr/share/scastd/setup_certbot.sh -e <email> -d <domain> [...] to obtain certificates."
+        fi
+    fi
+    systemctl enable --now certbot.timer >/dev/null 2>&1 || true
+fi
+
+#DEBHELPER#
+

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,0 +1,4 @@
+#!/usr/bin/make -f
+
+%:
+	dh $@

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,0 +1,3 @@
+pkgdatadir = $(datadir)/scastd
+
+dist_pkgdata_SCRIPTS = setup_certbot.sh


### PR DESCRIPTION
## Summary
- install `setup_certbot.sh` under `/usr/share/scastd/`
- run Certbot setup and enable renewal timer from Debian packages
- document certificate management and automated renewal

## Testing
- `./autogen.sh`
- `./configure`
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6898e0dfa40c832b9db7aa3cfefdca39