### PR TITLE
ci: validate required secrets and document configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,32 @@ on:
   pull_request:
     branches: [ "master" ]
 
+env:
+  DB_USER: ${{ secrets.DB_USER }}
+  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+  SQLITE_DB_PATH: ${{ secrets.SQLITE_DB_PATH }}
+  SSL_CERT: ${{ secrets.SSL_CERT }}
+  SSL_KEY: ${{ secrets.SSL_KEY }}
+
 jobs:
+  check-secrets:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify required secrets
+        run: |
+          missing=()
+          for s in DB_USER DB_PASSWORD SQLITE_DB_PATH SSL_CERT SSL_KEY; do
+            if [ -z "${!s}" ]; then
+              missing+=("$s")
+            fi
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "Missing required secrets: ${missing[*]}" >&2
+            exit 1
+          fi
   test:
     name: Build and test
+    needs: check-secrets
     strategy:
       matrix:
         runs-on:
@@ -38,6 +61,7 @@ jobs:
         run: make check
 
   lint:
+    needs: check-secrets
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/docs/CISecrets.md
+++ b/docs/CISecrets.md
@@ -1,0 +1,13 @@
+# CI Secrets
+
+The GitHub Actions workflow relies on several secrets that must be set in the repository's settings under **Settings > Secrets and variables > Actions**.
+
+| Secret | Description |
+| ------ | ----------- |
+| `DB_USER` | Username for database authentication. |
+| `DB_PASSWORD` | Password for `DB_USER`. |
+| `SQLITE_DB_PATH` | Path to a SQLite database used for tests. |
+| `SSL_CERT` | PEM-encoded TLS certificate. |
+| `SSL_KEY` | Private key for `SSL_CERT`. |
+
+Populate these secrets before running the CI workflow to prevent failures due to missing configuration.


### PR DESCRIPTION
## Summary
- validate required secrets before running jobs
- expose secret variables for DB and TLS settings in CI
- document repository secrets for maintainers

## Testing
- `./autogen.sh`
- `./configure`
- `make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689900e8d8c4832ba317a272b6014e19