### PR TITLE
Detect macOS and add Homebrew build paths

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -10,6 +10,18 @@ srcdir=$(dirname "$0")
 test -z "$srcdir" && srcdir=.
 cd "$srcdir"
 
+OS=$(uname -s)
+case "$OS" in
+  Darwin)
+    export PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:/opt/homebrew/share/pkgconfig:${PKG_CONFIG_PATH}"
+    export CPPFLAGS="-I/opt/homebrew/include ${CPPFLAGS}"
+    export LDFLAGS="-L/opt/homebrew/lib ${LDFLAGS}"
+    ;;
+  Linux)
+    export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:${PKG_CONFIG_PATH}"
+    ;;
+esac
+
 echo "Generating configuration files for $package, please wait...."
 autoreconf -I m4 --install --force --verbose
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,16 @@ AC_PROG_CXX
 AC_CANONICAL_HOST
 AM_PROG_LIBTOOL
 
+case $host_os in
+  darwin*)
+    AC_MSG_NOTICE([macOS detected - using Homebrew paths])
+    CPPFLAGS="$CPPFLAGS -I/opt/homebrew/include"
+    LDFLAGS="$LDFLAGS -L/opt/homebrew/lib"
+    PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:/opt/homebrew/share/pkgconfig:${PKG_CONFIG_PATH}"
+    export PKG_CONFIG_PATH
+    ;;
+esac
+
 dnl Use a modern C++ compiler with Linux specific options
 CXXFLAGS="$CXXFLAGS -std=c++17 -Wall -D_GNU_SOURCE"
 
@@ -52,6 +62,8 @@ AC_SUBST([SYSLOG_LIBS])
 dnl Make substitutions
 AC_SUBST(CXXFLAGS)
 AC_SUBST(LIBS)
+AC_SUBST(CPPFLAGS)
+AC_SUBST(LDFLAGS)
 
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile scripts/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
## Summary
- Detect host OS in `autogen.sh` to set `PKG_CONFIG_PATH`, `CPPFLAGS`, and `LDFLAGS` for macOS (Homebrew) or Linux.
- In `configure.ac`, append Homebrew include, library, and pkg-config paths when building on macOS and export them for pkg-config.
- Substitute `CPPFLAGS` and `LDFLAGS` so generated makefiles carry the new values.

## Testing
- `./configure` (Linux)
- `make` (Linux)
- `grep -E 'CPPFLAGS|LDFLAGS|PKG_CONFIG_PATH' -n config.log | head -n 20` (macOS simulation)
- `make` (macOS simulation, expected to fail at link step but shows Homebrew paths)


------
https://chatgpt.com/codex/tasks/task_e_68990ad1f710832bbb3ff99faf49f546