### PR TITLE
docs: clarify CI workflow and platform setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,34 @@ and PostgreSQL are currently supported.
 
 Building
 --------
-This repository omits generated build system files such as `configure` and `Makefile.in`.
-Run `./autogen.sh` (or `autoreconf -i && ./configure`) to generate them before building:
+This repository omits generated build system files such as `configure` and
+`Makefile.in`. Run `./autogen.sh` (or `autoreconf -i`) to generate them before
+building. Platform specific examples are shown below.
 
-Install the required development packages, including `libmicrohttpd-dev`
-and `libpq-dev` on Debian/Ubuntu or `libmicrohttpd` and `postgresql`
-via Homebrew on macOS, then run:
+### Debian/Ubuntu
+
+Install the required development packages and build the project:
 
 ```
+sudo apt-get update && sudo apt-get install -y build-essential autoconf automake \
+  libtool pkg-config libxml2-dev libcurl4-openssl-dev libmysqlclient-dev \
+  libpq-dev libmicrohttpd-dev
 ./autogen.sh
+./configure
+make
+```
+
+### macOS arm64
+
+Use Homebrew to install dependencies and set `PKG_CONFIG_PATH` so `pkg-config`
+can locate the libraries:
+
+```
+brew update
+brew install autoconf automake libtool pkg-config libxml2 curl mysql-client libpq libmicrohttpd
+export PKG_CONFIG_PATH=/opt/homebrew/opt/libpq/lib/pkgconfig:/opt/homebrew/opt/mysql-client/lib/pkgconfig:/opt/homebrew/opt/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH
+./autogen.sh
+./configure
 make
 ```
 
@@ -131,6 +150,25 @@ HTTP endpoints are namespaced by API version (e.g., `/v1/status.json`).
 Breaking changes will result in a new major version such as `/v2`. Older
 versions may continue to be served for a transition period, but
 unversioned paths are deprecated and may be removed in a future release.
+
+Continuous Integration and Releases
+-----------------------------------
+The project is built and tested by GitHub Actions on the following
+platforms:
+
+- macOS 14 (arm64)
+- Debian 12
+- Ubuntu 22.04
+- Ubuntu 24.04
+
+Each job bootstraps the build with `./autogen.sh`, configures, compiles
+and executes the test suite via `make check`.  After all tests and lint
+jobs succeed, a release job tags the commit on `master` as
+`v<run_number>` and publishes a GitHub release.
+
+Required secrets and environment variables are detailed in
+[docs/CISecrets.md](docs/CISecrets.md).  The complete CI workflow is
+described in [docs/CI.md](docs/CI.md).
 
 
 Troubleshooting

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,39 @@
+# Continuous Integration
+
+## Matrix
+
+The GitHub Actions workflow tests the project on the following platforms:
+
+| Runner | Architecture |
+| ------ | ------------ |
+| macOS 14 | arm64 |
+| Debian 12 | x86_64 |
+| Ubuntu 22.04 | x86_64 |
+| Ubuntu 24.04 | x86_64 |
+
+## Bootstrap Steps
+
+Each matrix job performs the same bootstrap and build procedure:
+
+```
+./autogen.sh
+./configure
+make
+make check
+```
+
+## Release Tagging
+
+When pushes land on the `master` branch and all tests and lint jobs have
+succeeded, a release job runs.  It tags the commit as `v<run_number>` and
+publishes a GitHub release using `actions/create-release`.
+
+## Environment and Secrets
+
+The workflow expects several secrets to be configured in the repository
+settings.  They are exposed to jobs as environment variables.  A detailed
+list is available in [CISecrets.md](CISecrets.md).
+
+For local development the same variables may be exported directly.  The
+runtime also honors `SCASTD_USERNAME`, `SCASTD_PASSWORD` and their
+`*_FILE` variants to supply credentials via the environment.

--- a/docs/CISecrets.md
+++ b/docs/CISecrets.md
@@ -1,6 +1,8 @@
-# CI Secrets
+# CI Secrets and Environment Variables
 
-The GitHub Actions workflow relies on several secrets that must be set in the repository's settings under **Settings > Secrets and variables > Actions**.
+The GitHub Actions workflow relies on several secrets that must be set in
+the repository's settings under **Settings > Secrets and variables >
+Actions**. These secrets are exposed to jobs as environment variables.
 
 | Secret | Description |
 | ------ | ----------- |
@@ -10,4 +12,17 @@ The GitHub Actions workflow relies on several secrets that must be set in the re
 | `SSL_CERT` | PEM-encoded TLS certificate. |
 | `SSL_KEY` | Private key for `SSL_CERT`. |
 
-Populate these secrets before running the CI workflow to prevent failures due to missing configuration.
+Populate these secrets before running the CI workflow to prevent failures
+due to missing configuration.  For local development the same variables
+can be exported directly.
+
+## Environment Variables
+
+Additional environment variables influence local and CI builds:
+
+| Variable | Purpose |
+| -------- | ------- |
+| `SCASTD_USERNAME` / `SCASTD_USERNAME_FILE` | Override or provide the username used by the daemon. |
+| `SCASTD_PASSWORD` / `SCASTD_PASSWORD_FILE` | Override or provide the password used by the daemon. |
+| `PKG_CONFIG_PATH` | On macOS, helps `pkg-config` locate Homebrew-installed libraries. |
+| `GITHUB_TOKEN` | Automatically provided in CI for release tagging. |


### PR DESCRIPTION
## Summary
- document CI matrix, bootstrap steps, and release tagging
- add Debian/Ubuntu and macOS arm64 build examples
- describe required secrets and environment variables for local and CI builds

## Testing
- `./autogen.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68990cedf0c0832baae8fdd067a33139