### PR TITLE
Expand CI matrix and capture build logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
+---
 name: CI
 
-on:
+"on":
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 env:
   DB_USER: ${{ secrets.DB_USER }}
@@ -34,31 +35,69 @@ jobs:
     needs: check-secrets
     strategy:
       matrix:
-        runs-on:
-          - macos-14
-          - debian-12
-          - ubuntu-22.04
-          - ubuntu-24.04
-    runs-on: ${{ matrix.runs-on }}
+        include:
+          - os: debian-12
+            arch: x64
+          - os: ubuntu-22.04
+            arch: x64
+          - os: ubuntu-24.04
+            arch: x64
+          - os: macos-14
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies (Debian/Ubuntu)
-        if: matrix.runs-on == 'debian-12' || matrix.runs-on == 'ubuntu-22.04' || matrix.runs-on == 'ubuntu-24.04'
-        run: sudo apt-get update && sudo apt-get install -y build-essential autoconf automake libtool pkg-config libxml2-dev libcurl4-openssl-dev libmysqlclient-dev libpq-dev libmicrohttpd-dev
+        if: contains('debian-12 ubuntu-22.04 ubuntu-24.04', matrix.os)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            autoconf automake libtool pkg-config \
+            libxml2-dev libcurl4-openssl-dev \
+            libmysqlclient-dev libpq-dev libmicrohttpd-dev
       - name: Install dependencies (macOS)
-        if: matrix.runs-on == 'macos-14'
+        if: matrix.os == 'macos-14'
         run: |
           brew update
-          brew install autoconf automake libtool pkg-config libxml2 curl mysql-client libpq libmicrohttpd
-          echo "PKG_CONFIG_PATH=/opt/homebrew/opt/libpq/lib/pkgconfig:/opt/homebrew/opt/mysql-client/lib/pkgconfig:/opt/homebrew/opt/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          brew install \
+            autoconf automake libtool pkg-config \
+            libxml2 curl mysql-client libpq libmicrohttpd
+          echo "PKG_CONFIG_PATH=/opt/homebrew/opt/libpq/lib/pkgconfig:\
+          /opt/homebrew/opt/mysql-client/lib/pkgconfig:\
+          /opt/homebrew/opt/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH" >> \
+            $GITHUB_ENV
       - name: Generate configure script
-        run: ./autogen.sh
+        run: |
+          set -o pipefail
+          ./autogen.sh 2>&1 | tee autogen.log
       - name: Configure
-        run: ./configure
+        run: |
+          set -o pipefail
+          ./configure 2>&1 | tee configure.log
       - name: Build
-        run: make
+        run: |
+          set -o pipefail
+          make 2>&1 | tee build.log
       - name: Run unit tests
-        run: make check
+        run: |
+          set -o pipefail
+          make check 2>&1 | tee test.log
+      - name: Upload build artifacts and logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-${{ matrix.arch }}-logs
+          path: |
+            autogen.log
+            configure.log
+            build.log
+            test.log
+            config.log
+            tests/test-suite.log
+            src/scastd
+            src/.libs/scastd
+          if-no-files-found: ignore
 
   lint:
     needs: check-secrets
@@ -68,8 +107,10 @@ jobs:
       - name: Install cppcheck
         run: sudo apt-get update && sudo apt-get install -y cppcheck
       - name: Run cppcheck
-        run: cppcheck --enable=all --std=c++17 --suppress=missingIncludeSystem src tests
-
+        run: |
+          cppcheck --enable=all --std=c++17 \
+            --suppress=missingIncludeSystem \
+            src tests
   release:
     needs: [test, lint]
     runs-on: ubuntu-24.04
@@ -85,4 +126,3 @@ jobs:
           release_name: Release ${{ github.run_number }}
           draft: false
           prerelease: false
-


### PR DESCRIPTION
## Summary
- add CI matrix for Debian 12, Ubuntu 22.04, Ubuntu 24.04 (x64) and macOS 14 (arm64)
- run autogen/configure/build/test with log capture for each OS
- upload build artifacts and logs for easier debugging

## Testing
- `yamllint .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_689913868a0c832baabfc5f3e9225280