### PR TITLE
ci: relax certificate checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Validate SSL certificate
+        run: |
+          if [ -z "$SSL_CERT" ] || [ ! -f "$SSL_CERT" ]; then
+            echo "SSL certificate file not found: $SSL_CERT" >&2
+            exit 1
+          fi
+          openssl x509 -checkend 0 -noout -in "$SSL_CERT"
+      - name: Test curl with insecure flag
+        run: |
+          curl --insecure -sS https://self-signed.badssl.com/ -o /dev/null
       - name: Install dependencies (Debian/Ubuntu)
         if: contains('debian-12 ubuntu-22.04 ubuntu-24.04', matrix.os)
         run: |


### PR DESCRIPTION
## Summary
- add SSL cert expiration pre-check
- fetch self-signed URL with curl --insecure

## Testing
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `apt-get install -y build-essential autoconf automake libtool pkg-config libxml2-dev libcurl4-openssl-dev libmysqlclient-dev libpq-dev libmicrohttpd-dev >/tmp/apt_install.log && tail -n 20 /tmp/apt_install.log`
- `./autogen.sh >/tmp/autogen.log && tail -n 20 /tmp/autogen.log`
- `./configure >/tmp/configure.log && tail -n 20 /tmp/configure.log`
- `make >/tmp/make.log && tail -n 20 /tmp/make.log`
- `make check >/tmp/test.log && tail -n 20 /tmp/test.log` *(failed: exit status 1)*
- `tail -n 20 tests/test-suite.log`
- `curl --insecure -sS https://self-signed.badssl.com/ -o /dev/null && echo "curl succeeded"`


------
https://chatgpt.com/codex/tasks/task_e_68991d03ff30832b802e04ae3edd9105