### PR TITLE
chore(ci): remove ssl prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ env:
   DB_USER: ${{ secrets.DB_USER }}
   DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
   SQLITE_DB_PATH: ${{ secrets.SQLITE_DB_PATH }}
-  SSL_CERT: ${{ secrets.SSL_CERT }}
-  SSL_KEY: ${{ secrets.SSL_KEY }}
 
 jobs:
   check-secrets:
@@ -21,7 +19,7 @@ jobs:
       - name: Verify required secrets
         run: |
           missing=()
-          for s in DB_USER DB_PASSWORD SQLITE_DB_PATH SSL_CERT SSL_KEY; do
+          for s in DB_USER DB_PASSWORD SQLITE_DB_PATH; do
             if [ -z "${!s}" ]; then
               missing+=("$s")
             fi
@@ -47,16 +45,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Validate SSL certificate
+      - name: Test HTTP request
         run: |
-          if [ -z "$SSL_CERT" ] || [ ! -f "$SSL_CERT" ]; then
-            echo "SSL certificate file not found: $SSL_CERT" >&2
-            exit 1
-          fi
-          openssl x509 -checkend 0 -noout -in "$SSL_CERT"
-      - name: Test curl with insecure flag
-        run: |
-          curl --insecure -sS https://self-signed.badssl.com/ -o /dev/null
+          curl -sS http://example.com
       - name: Install dependencies (Debian/Ubuntu)
         if: contains('debian-12 ubuntu-22.04 ubuntu-24.04', matrix.os)
         run: |


### PR DESCRIPTION
## Summary
- remove SSL_CERT and SSL_KEY secrets from CI
- drop TLS validation step and test curl over plain HTTP

## Testing
- `apt-get update`
- `apt-get install -y build-essential autoconf automake libtool pkg-config libxml2-dev libcurl4-openssl-dev libmysqlclient-dev libpq-dev libmicrohttpd-dev`
- `./autogen.sh`
- `./configure`
- `make`
- `make check` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6899212c1f48832ba44e952b8910c366