### PR TITLE
Guard optional HTTPS test

### DIFF
--- a/tests/test_http.cpp
+++ b/tests/test_http.cpp
@@ -117,7 +117,8 @@ TEST_CASE("HTTP server uptime requires auth") {
     curl_easy_cleanup(curl);
     server.stop();
 }
-
+#ifdef SCASD_ENABLE_HTTPS_TESTS
+// Optional test that exercises HTTPS support when certificates are provided.
 TEST_CASE("HTTPS server responds with status") {
     const char *certEnv = std::getenv("SSL_CERT");
     const char *keyEnv = std::getenv("SSL_KEY");
@@ -160,3 +161,4 @@ TEST_CASE("HTTPS server responds with status") {
     std::filesystem::remove(certPath);
     std::filesystem::remove(keyPath);
 }
+#endif


### PR DESCRIPTION
## Summary
- Guard HTTPS server test behind `SCASD_ENABLE_HTTPS_TESTS` so default tests use only HTTP.

## Testing
- `./autogen.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6899230e63f4832b995e5117998c4adb