### PR TITLE
docs: remove TLS secrets from CISecrets

### DIFF
--- a/docs/CISecrets.md
+++ b/docs/CISecrets.md
@@ -4,13 +4,13 @@ The GitHub Actions workflow relies on several secrets that must be set in
 the repository's settings under **Settings > Secrets and variables >
 Actions**. These secrets are exposed to jobs as environment variables.
 
+CI runs exclusively over HTTP; TLS validation is handled manually, so no TLS certificate or key secrets are required.
+
 | Secret | Description |
 | ------ | ----------- |
 | `DB_USER` | Username for database authentication. |
 | `DB_PASSWORD` | Password for `DB_USER`. |
 | `SQLITE_DB_PATH` | Path to a SQLite database used for tests. |
-| `SSL_CERT` | PEM-encoded TLS certificate. |
-| `SSL_KEY` | Private key for `SSL_CERT`. |
 
 Populate these secrets before running the CI workflow to prevent failures
 due to missing configuration.  For local development the same variables


### PR DESCRIPTION
## Summary
- clarify CI uses HTTP and manual TLS validation
- drop SSL_CERT and SSL_KEY secrets from docs

## Testing
- `./autogen.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689925cc315c832b932e6d31c2ffa874