### PR TITLE
Add glibtoolize fallback in autogen script

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,10 +8,9 @@ command -v aclocal >/dev/null 2>&1 || {
   echo "Error: 'aclocal' not found. Please install automake." >&2
   exit 1
 }
-command -v libtoolize >/dev/null 2>&1 || {
-  echo "Error: 'libtoolize' not found. Please install libtool." >&2
-  exit 1
-}
+LIBTOOLIZE=$(command -v libtoolize 2>/dev/null || command -v glibtoolize)
+[[ -z "$LIBTOOLIZE" ]] && { echo "libtoolize/glibtoolize not found"; exit 1; }
+"$LIBTOOLIZE" --force --copy
 
 package="scastd"
 


### PR DESCRIPTION
## Summary
- allow autogen.sh to use glibtoolize when libtoolize is unavailable

## Testing
- `bash -n autogen.sh`


------
https://chatgpt.com/codex/tasks/task_e_689941eb02b0832b89d3a80601df5417