### PR TITLE
Enable gettext and link against libintl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,10 @@ LIBS="$LIBS $OPENSSL_LIBS"
 AC_CHECK_LIB([syslog], [openlog], [SYSLOG_LIBS="-lsyslog"], [SYSLOG_LIBS=""])
 AC_SUBST([SYSLOG_LIBS])
 
+AM_GNU_GETTEXT([external])
+AM_GNU_GETTEXT_VERSION([0.22])
+AC_SUBST([LIBINTL])
+
 
 dnl Make substitutions
 AC_SUBST(CXXFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,4 +15,4 @@ scastd_SOURCES = \
     db/PostgresDatabase.cpp \
     db/SQLiteDatabase.cpp
 
-scastd_LDADD = $(SYSLOG_LIBS)
+scastd_LDADD = $(SYSLOG_LIBS) $(LIBINTL)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,6 +6,6 @@ unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp te
     ../src/CurlClient.cpp ../src/logger.cpp ../src/StatusLogger.cpp \
     ../src/db/MySQLDatabase.cpp ../src/db/MariaDBDatabase.cpp \
     ../src/db/PostgresDatabase.cpp
-unit_tests_LDADD = $(DEPS_LIBS)
+unit_tests_LDADD = $(DEPS_LIBS) $(LIBINTL)
 
 TESTS = unit_tests


### PR DESCRIPTION
## Summary
- Add GNU gettext configuration macros and export LIBINTL.
- Link `scastd` and unit tests against libintl.

## Testing
- `bash ./autogen.sh` *(fails: AM_GNU_GETTEXT_VERSION requires gettext 0.22)*
- `./configure` *(fails: No such file or directory)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68994a1c07d0832b814f0c3b196cbfe8