### PR TITLE
Replace obsolete libtool macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_CONFIG_HEADERS([config.h])
 
 AC_PROG_CXX
 AC_CANONICAL_HOST
-AM_PROG_LIBTOOL
+LT_INIT
 
 case $host_os in
   darwin*)


### PR DESCRIPTION
## Summary
- use LT_INIT in `configure.ac` instead of deprecated AM_PROG_LIBTOOL

## Testing
- `autoupdate -v configure.ac 2>&1 | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_689950ce5dec832ba07a96f735a67f98