### PR TITLE
Enable subdir object builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT([scastd],[1.0])
 AC_CONFIG_MACRO_DIRS([m4])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src/scastd.cpp])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
## Summary
- Enable subdir-objects in Automake so compilation outputs reside next to sources

## Testing
- `autoreconf -I m4 --install --force --verbose`
- `./configure`
- `make -j$(nproc)`
- `find src -name '*.o'`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689959309bec832bbdce506c0fd2e53d