### PR TITLE
Improve autotools checks in autogen

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,8 +8,12 @@ command -v aclocal >/dev/null 2>&1 || {
   echo "Error: 'aclocal' not found. Please install automake." >&2
   exit 1
 }
+command -v autopoint >/dev/null 2>&1 || {
+  echo "Error: 'autopoint' not found. Please install gettext."
+  exit 1
+}
 LIBTOOLIZE=$(command -v libtoolize 2>/dev/null || command -v glibtoolize)
-[[ -z "$LIBTOOLIZE" ]] && { echo "libtoolize/glibtoolize not found"; exit 1; }
+[ -z "$LIBTOOLIZE" ] && { echo "libtoolize/glibtoolize not found"; exit 1; }
 "$LIBTOOLIZE" --force --copy
 
 package="scastd"


### PR DESCRIPTION
## Summary
- add autopoint availability check and recommend installing gettext
- use POSIX-compatible test for libtoolize/glibtoolize

## Testing
- `shellcheck autogen.sh`
- `./autogen.sh` *(fails: autopoint requires gettext-0.22 or newer)*

------
https://chatgpt.com/codex/tasks/task_e_689a6b158ed8832b8382ffa2ea790fc6