### PR TITLE
ci: add gettext to dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
-            autoconf automake libtool pkg-config \
+            autoconf automake libtool pkg-config gettext \
             libxml2-dev libcurl4-openssl-dev \
             libmysqlclient-dev libpq-dev libmicrohttpd-dev
       - name: Install dependencies (macOS)
@@ -38,12 +38,13 @@ jobs:
         run: |
           brew update
           brew install \
-            autoconf automake libtool pkg-config \
+            autoconf automake libtool pkg-config gettext \
             libxml2 curl mysql-client libpq libmicrohttpd
           echo "PKG_CONFIG_PATH=/opt/homebrew/opt/libpq/lib/pkgconfig:\
           /opt/homebrew/opt/mysql-client/lib/pkgconfig:\
           /opt/homebrew/opt/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH" >> \
             $GITHUB_ENV
+          echo "PATH=/opt/homebrew/opt/gettext/bin:$PATH" >> $GITHUB_ENV
       - name: Generate configure script
         run: |
           set -o pipefail


### PR DESCRIPTION
## Summary
- add gettext to Debian/Ubuntu dependencies
- install gettext on macOS and expose its autopoint in PATH

## Testing
- `./autogen.sh` *(fails: AM_GNU_GETTEXT_VERSION requires gettext-0.22)*


------
https://chatgpt.com/codex/tasks/task_e_689a6d1441c4832b88127754722be706