### PR TITLE
Add setter for configuration values

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -128,6 +128,10 @@ int Config::Get(const std::string &key, int def) const {
     return def;
 }
 
+void Config::Set(const std::string &key, const std::string &value) {
+    values[key] = value;
+}
+
 bool Config::Get(const std::string &key, bool def) const {
     std::map<std::string, std::string>::const_iterator it = values.find(key);
     if (it != values.end()) {

--- a/src/Config.h
+++ b/src/Config.h
@@ -37,6 +37,8 @@ public:
     int Get(const std::string &key, int def) const;
     bool Get(const std::string &key, bool def) const;
 
+    void Set(const std::string &key, const std::string &value);
+
     std::string AccessLog() const;
     std::string ErrorLog() const;
     std::string DebugLog() const;


### PR DESCRIPTION
## Summary
- declare new `Config::Set` method in `Config.h`
- implement `Config::Set` to update internal map

## Testing
- `./autogen.sh` *(fails: 'aclocal' not found)*
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689a710ec260832b930dedc8c8be7542