### PR TITLE
Use getopt_long for CLI options and add test mode

### DIFF
--- a/src/scastd.h
+++ b/src/scastd.h
@@ -24,10 +24,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define SCASTD_H
 
 #include <string>
+#include <map>
 
 namespace scastd {
-int run(const std::string &configPath);
-int dumpDatabase(const std::string &configPath, const std::string &dumpDir);
+int run(const std::string &configPath,
+        const std::map<std::string, std::string> &overrides);
+int dumpDatabase(const std::string &configPath,
+                 const std::map<std::string, std::string> &overrides,
+                 const std::string &dumpDir);
 }
 
 #endif // SCASTD_H


### PR DESCRIPTION
## Summary
- Replace manual CLI parsing with `getopt_long`, adding options for config, networking, database, SSL, and test mode
- Allow CLI options to override configuration via `Config::Set`
- Introduce test mode that validates database connectivity

## Testing
- `./autogen.sh` *(fails: autopoint requires gettext-0.22)*
- `g++ -c src/main.cpp -I src -std=c++11` *(fails: libpq-fe.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a71b406b0832bb29d6716ad2c296a