### PR TITLE
Add configurable HTTP bind address

### DIFF
--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -34,6 +34,7 @@ public:
     ~HttpServer();
 
     bool start(int port = 8333,
+               const std::string &ip = "",
                const std::string &user = "",
                const std::string &pass = "",
                int threads = 1,

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -397,18 +397,20 @@ int run(const std::string &configPath,
         }
         bool httpEnabled = cfg.Get("http_enabled", true);
         int httpPort = cfg.Get("http_port", 8333);
+        std::string httpIp = cfg.Get("ip", "");
         std::string httpUser = cfg.Get("http_username", "");
         std::string httpPass = cfg.Get("http_password", "");
         bool sslEnabled = cfg.Get("ssl_enabled", false);
         std::string sslCert = cfg.Get("ssl_cert", "");
         std::string sslKey = cfg.Get("ssl_key", "");
         if (httpEnabled) {
-                if (!httpServer.start(httpPort, httpUser, httpPass,
+                if (!httpServer.start(httpPort, httpIp, httpUser, httpPass,
                                        threadCount,
                                        sslEnabled, sslCert, sslKey)) {
                         char lbuf[256];
-                        snprintf(lbuf, sizeof(lbuf), _("Failed to start HTTP%s server on port %d"),
-                                sslEnabled ? "S" : "", httpPort);
+                        snprintf(lbuf, sizeof(lbuf), _("Failed to start HTTP%s server on %s:%d"),
+                                sslEnabled ? "S" : "",
+                                httpIp.empty() ? "*" : httpIp.c_str(), httpPort);
                         logger.logError(lbuf);
                 }
         }

--- a/tests/test_http.cpp
+++ b/tests/test_http.cpp
@@ -40,7 +40,7 @@ static size_t write_cb(void *contents, size_t size, size_t nmemb, void *userp) {
 TEST_CASE("HTTP server responds with status") {
     setenv("SCASD_NO_DAEMON", "1", 1);
     scastd::HttpServer server;
-    REQUIRE(server.start(18080, "", "", 1, false, "", ""));
+    REQUIRE(server.start(18080, "127.0.0.1", "", "", 1, false, "", ""));
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     CURL *curl = curl_easy_init();
@@ -85,7 +85,7 @@ TEST_CASE("HTTP server responds with status") {
 TEST_CASE("HTTP server uptime requires auth") {
     setenv("SCASD_NO_DAEMON", "1", 1);
     scastd::HttpServer server;
-    REQUIRE(server.start(18081, "user", "pass", 1, false, "", ""));
+    REQUIRE(server.start(18081, "127.0.0.1", "user", "pass", 1, false, "", ""));
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     CURL *curl = curl_easy_init();
@@ -139,7 +139,7 @@ TEST_CASE("HTTPS server responds with status") {
 
     setenv("SCASD_NO_DAEMON", "1", 1);
     scastd::HttpServer server;
-    REQUIRE(server.start(18443, "", "", 1, true, certPath.string(), keyPath.string()));
+    REQUIRE(server.start(18443, "127.0.0.1", "", "", 1, true, certPath.string(), keyPath.string()));
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     CURL *curl = curl_easy_init();


### PR DESCRIPTION
## Summary
- allow `HttpServer::start` to accept a bind IP and use it when starting the MicroHTTPd daemon
- plumb bind IP through `scastd.cpp::run` so config and CLI `--ip` control the HTTP listener
- update HTTP server tests for the new parameter

## Testing
- `g++ -std=c++17 -Isrc -Itests -o /tmp/test_http tests/test_main.cpp tests/test_http.cpp src/HttpServer.cpp src/StatusLogger.cpp src/logger.cpp src/i18n.cpp -lmicrohttpd -lcurl -lssl -lcrypto -lsqlite3 -pthread`
- `/tmp/test_http`


------
https://chatgpt.com/codex/tasks/task_e_689a7b1fb5c8832bb72adfacd5c5d991