### PR TITLE
ci: install autopoint in dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
-            autoconf automake libtool pkg-config gettext \
+            autoconf automake libtool pkg-config gettext autopoint \
             libxml2-dev libcurl4-openssl-dev \
             libmysqlclient-dev libpq-dev libmicrohttpd-dev
       - name: Install dependencies (macOS)


### PR DESCRIPTION
## Summary
- install autopoint on Debian/Ubuntu runners so autogen.sh has gettext tooling

## Testing
- `yamllint .github/workflows/dev.yml`

------
https://chatgpt.com/codex/tasks/task_e_689a82615dd4832b9c6ec1bbcf9fa766