### PR TITLE
ci: add mysql connector for macOS

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -48,19 +48,31 @@ jobs:
           brew install \
             autoconf automake libtool pkg-config gettext \
             libxml2 curl mysql-client libpq libmicrohttpd
-          echo "PKG_CONFIG_PATH=/opt/homebrew/opt/libpq/lib/pkgconfig:\
-          /opt/homebrew/opt/mysql-client/lib/pkgconfig:\
-          /opt/homebrew/opt/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH" >> \
-            $GITHUB_ENV
-          echo "PATH=/opt/homebrew/opt/gettext/bin:$PATH" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I/opt/homebrew/opt/mysql-client/include $CPPFLAGS" >> $GITHUB_ENV
-          echo "LDFLAGS=-L/opt/homebrew/opt/mysql-client/lib $LDFLAGS" >> $GITHUB_ENV
-          echo "PATH=/opt/homebrew/opt/mysql-client/bin:$PATH" >> $GITHUB_ENV
-          curl -LO https://dev.mysql.com/get/Downloads/Connector-C++/mysql-connector-c++-9.4.0-macos15-arm64.tar.gz
-          tar -xf mysql-connector-c++-9.4.0-macos15-arm64.tar.gz
-          echo "CPPFLAGS=-I$PWD/mysql-connector-c++-9.4.0-macos15-arm64/include $CPPFLAGS" >> $GITHUB_ENV
-          echo "LDFLAGS=-L$PWD/mysql-connector-c++-9.4.0-macos15-arm64/lib $LDFLAGS" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=$PWD/mysql-connector-c++-9.4.0-macos15-arm64/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          B=/opt/homebrew/opt
+          export PKG_CONFIG_PATH=$B/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH
+          export PKG_CONFIG_PATH=$B/mysql-client/lib/pkgconfig:$PKG_CONFIG_PATH
+          export PKG_CONFIG_PATH=$B/libpq/lib/pkgconfig:$PKG_CONFIG_PATH
+          export PATH=$B/mysql-client/bin:$PATH
+          export PATH=$B/gettext/bin:$PATH
+          export CPPFLAGS=-I$B/mysql-client/include $CPPFLAGS
+          export LDFLAGS=-L$B/mysql-client/lib $LDFLAGS
+          MYSQL_VER=mysql-connector-c++-9.4.0-macos15-arm64
+          MYSQL_URL=https://dev.mysql.com/get/Downloads/Connector-C++/$MYSQL_VER.tar.gz
+          curl -LO "$MYSQL_URL"
+          tar -xf "$MYSQL_VER.tar.gz"
+          CONN_DIR="${PWD}/$MYSQL_VER"
+          export PATH="$CONN_DIR/bin:$PATH"
+          export CPPFLAGS="-I$CONN_DIR/include $CPPFLAGS"
+          export LDFLAGS="-L$CONN_DIR/lib $LDFLAGS"
+          export PKG_CONFIG_PATH="$CONN_DIR/lib/pkgconfig:$PKG_CONFIG_PATH"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
+          echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          echo "PATH=$PATH"
+          echo "CPPFLAGS=$CPPFLAGS"
+          echo "LDFLAGS=$LDFLAGS"
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
       - name: Generate configure script
         run: |
           set -o pipefail


### PR DESCRIPTION
## Summary
- download and expose MySQL C++ connector in macOS dev workflow
- export include/lib/pkgconfig flags and echo them for later steps

## Testing
- `yamllint .github/workflows/dev.yml`


------
https://chatgpt.com/codex/tasks/task_e_689a91f9441c832ba6bc2ee892fd80be