### PR TITLE
Use conditional MySQL include

### DIFF
--- a/src/db/MySQLDatabase.h
+++ b/src/db/MySQLDatabase.h
@@ -24,7 +24,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define MYSQLDATABASE_H
 
 #include "IDatabase.h"
+#if __has_include(<mysql/mysql.h>)
+#include <mysql/mysql.h>
+#else
 #include <mysql.h>
+#endif
 
 class MySQLDatabase : public IDatabase {
 public:


### PR DESCRIPTION
## Summary
- conditionally include the proper MySQL header depending on include path availability

## Testing
- `./autogen.sh` *(fails: requires gettext 0.22 or newer)*

------
https://chatgpt.com/codex/tasks/task_e_689aababc6f0832ba385a06bfb4a1447