### PR TITLE
Install gettext and autopoint before running autogen

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,7 +30,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
-            autoconf automake libtool pkg-config gettext autopoint \
+            autoconf automake libtool pkg-config \
+            gettext \
+            autopoint \
             libxml2-dev libcurl4-openssl-dev \
             libmysqlclient-dev libpq-dev libmicrohttpd-dev
           wget https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.tar.gz
@@ -73,10 +75,11 @@ jobs:
           echo "CPPFLAGS=$CPPFLAGS"
           echo "LDFLAGS=$LDFLAGS"
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
-      - name: Generate configure script
+      - name: Verify autopoint
+        run: autopoint --version
+      - name: Run autogen script
         run: |
           set -o pipefail
-          autopoint --version
           ./autogen.sh 2>&1 | tee autogen.log
       - name: Configure
         run: |


### PR DESCRIPTION
## Summary
- Ensure Debian/Ubuntu builds install gettext and autopoint packages
- Run `./autogen.sh` only after dependencies are installed and verify autopoint availability

## Testing
- `yamllint .github/workflows/dev.yml`
- `./autogen.sh` *(fails: AM_GNU_GETTEXT_VERSION requires gettext-0.22)*


------
https://chatgpt.com/codex/tasks/task_e_689aac5dcf64832bbeabe80bbd7dc09c