### PR TITLE
ci: align macOS MySQL setup and export flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,18 +35,43 @@ jobs:
             build-essential \
             autoconf automake libtool pkg-config \
             libxml2-dev libcurl4-openssl-dev \
-            libmysqlclient-dev libpq-dev libmicrohttpd-dev
+            libmysqlclient-dev mariadb-client libpq-dev libmicrohttpd-dev
+          MYSQL_CFLAGS=$(mysql_config --cflags)
+          MYSQL_LIBS=$(mysql_config --libs)
+          export CPPFLAGS="$MYSQL_CFLAGS $CPPFLAGS"
+          export LDFLAGS="$MYSQL_LIBS $LDFLAGS"
+          export PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH"
+          echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
+          echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Install dependencies (macOS)
         if: matrix.os == 'macos-14'
         run: |
           brew update
           brew install \
-            autoconf automake libtool pkg-config \
+            autoconf automake libtool pkg-config gettext \
             libxml2 curl mysql-client libpq libmicrohttpd
-          echo "PKG_CONFIG_PATH=/opt/homebrew/opt/libpq/lib/pkgconfig:\
-          /opt/homebrew/opt/mysql-client/lib/pkgconfig:\
-          /opt/homebrew/opt/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH" >> \
-            $GITHUB_ENV
+          B=/opt/homebrew/opt
+          export PKG_CONFIG_PATH=$B/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH
+          export PKG_CONFIG_PATH=$B/mysql-client/lib/pkgconfig:$PKG_CONFIG_PATH
+          export PKG_CONFIG_PATH=$B/libpq/lib/pkgconfig:$PKG_CONFIG_PATH
+          export PATH=$B/mysql-client/bin:$PATH
+          export PATH=$B/gettext/bin:$PATH
+          export CPPFLAGS=-I$B/mysql-client/include $CPPFLAGS
+          export LDFLAGS=-L$B/mysql-client/lib $LDFLAGS
+          MYSQL_VER=mysql-connector-c++-9.4.0-macos15-arm64
+          MYSQL_URL=https://dev.mysql.com/get/Downloads/Connector-C++/$MYSQL_VER.tar.gz
+          curl -LO "$MYSQL_URL"
+          tar -xf "$MYSQL_VER.tar.gz"
+          CONN_DIR="${PWD}/$MYSQL_VER"
+          export PATH="$CONN_DIR/bin:$PATH"
+          export CPPFLAGS="-I$CONN_DIR/include $CPPFLAGS"
+          export LDFLAGS="-L$CONN_DIR/lib $LDFLAGS"
+          export PKG_CONFIG_PATH="$CONN_DIR/lib/pkgconfig:$PKG_CONFIG_PATH"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
+          echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Generate configure script
         run: |
           set -o pipefail

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,7 +34,7 @@ jobs:
             gettext \
             autopoint \
             libxml2-dev libcurl4-openssl-dev \
-            libmysqlclient-dev libpq-dev libmicrohttpd-dev
+            libmysqlclient-dev mariadb-client libpq-dev libmicrohttpd-dev
           wget https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.tar.gz
           tar -xf gettext-0.22.tar.gz
           cd gettext-0.22
@@ -43,6 +43,14 @@ jobs:
           sudo make install
           cd ..
           echo "PATH=/usr/local/bin:$PATH" >> $GITHUB_ENV
+          MYSQL_CFLAGS=$(mysql_config --cflags)
+          MYSQL_LIBS=$(mysql_config --libs)
+          export CPPFLAGS="$MYSQL_CFLAGS $CPPFLAGS"
+          export LDFLAGS="$MYSQL_LIBS $LDFLAGS"
+          export PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH"
+          echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
+          echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Install dependencies (macOS)
         if: matrix.os == 'macos-14'
         run: |


### PR DESCRIPTION
## Summary
- use consistent MySQL Connector/C++ extraction for macOS jobs
- export MySQL build flags on Debian and Ubuntu jobs

## Testing
- `./autogen.sh` *(fails: autopoint requires gettext-0.22)*
- `./configure` *(fails: cannot find required auxiliary files: compile config.guess config.sub missing install-sh)*

------
https://chatgpt.com/codex/tasks/task_e_689abc95aa00832bba42599af8429846