### PR TITLE
tests: include Config header with relative path

### DIFF
--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "catch.hpp"
-#include "Config.h"
+#include "../src/Config.h"
 #include <fstream>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
## Summary
- include `src/Config.h` in `tests/test_config.cpp` via relative path to avoid ambiguous includes

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689ac583d030832ba345639fe78b6f2c