### PR TITLE
fix: use lib64 for MySQL connector on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
           CONN_DIR="${PWD}/$MYSQL_VER"
           export PATH="$CONN_DIR/bin:$PATH"
           export CPPFLAGS="-I$CONN_DIR/include $CPPFLAGS"
-          export LDFLAGS="-L$CONN_DIR/lib $LDFLAGS"
-          export PKG_CONFIG_PATH="$CONN_DIR/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export LDFLAGS="-L$CONN_DIR/lib64 $LDFLAGS"
+          export PKG_CONFIG_PATH="$CONN_DIR/lib64/pkgconfig:$PKG_CONFIG_PATH"
           echo "PATH=$PATH" >> $GITHUB_ENV
           echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- ensure macOS workflow links against MySQL connector's `lib64`

## Testing
- `./autogen.sh` *(fails: autopoint requires gettext-0.22)*

------
https://chatgpt.com/codex/tasks/task_e_689acce69db8832b8478b46e51df9c87