### PR TITLE
chore: simplify CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,6 @@ jobs:
         run: |
           set -o pipefail
           make 2>&1 | tee build.log
-      - name: Run unit tests
-        run: |
-          set -o pipefail
-          make check 2>&1 | tee test.log
       - name: Verify scastd --help
         run: |
           set -o pipefail
@@ -104,10 +100,8 @@ jobs:
             autogen.log
             configure.log
             build.log
-            test.log
             scastd-help.log
             config.log
-            tests/test-suite.log
             src/scastd
             src/.libs/scastd
           if-no-files-found: ignore
@@ -122,7 +116,7 @@ jobs:
         run: |
           cppcheck --enable=all --std=c++17 \
             --suppress=missingIncludeSystem \
-            src tests
+            src
   release:
     needs: [test, lint]
     runs-on: ubuntu-24.04

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -47,7 +47,8 @@ jobs:
           MYSQL_LIBS=$(mysql_config --libs)
           export CPPFLAGS="$MYSQL_CFLAGS $CPPFLAGS"
           export LDFLAGS="$MYSQL_LIBS $LDFLAGS"
-          export PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH"
+          PCP=/usr/lib/x86_64-linux-gnu/pkgconfig
+          export PKG_CONFIG_PATH="$PCP:$PKG_CONFIG_PATH"
           echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
@@ -97,10 +98,10 @@ jobs:
         run: |
           set -o pipefail
           make 2>&1 | tee build.log
-      - name: Run unit tests
+      - name: Verify scastd --help
         run: |
           set -o pipefail
-          make check 2>&1 | tee test.log
+          ./src/scastd --help 2>&1 | tee scastd-help.log
       - name: Upload build artifacts and logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -110,9 +111,8 @@ jobs:
             autogen.log
             configure.log
             build.log
-            test.log
+            scastd-help.log
             config.log
-            tests/test-suite.log
             src/scastd
             src/.libs/scastd
           if-no-files-found: ignore
@@ -127,7 +127,7 @@ jobs:
         run: |
           cppcheck --enable=all --std=c++17 \
             --suppress=missingIncludeSystem \
-            src tests
+            src
   release:
     needs: [test, lint]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- drop unit-test steps and artifact uploads from CI workflows
- ensure Debian/Ubuntu and macOS jobs set up MySQL dependencies
- run `./src/scastd --help` after building to validate binary

## Testing
- `yamllint .github/workflows/ci.yml .github/workflows/dev.yml`


------
https://chatgpt.com/codex/tasks/task_e_689ad4ac6d08832b95b16558367030c4