### PR TITLE
ci: verify scastd help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,9 @@ jobs:
           make 2>&1 | tee build.log
       - name: Verify scastd --help
         run: |
-          set -o pipefail
-          ./src/scastd --help 2>&1 | tee scastd-help.log
+          set -e
+          ./src/scastd --help > scastd-help.log 2>&1
+          cat scastd-help.log
       - name: Upload build artifacts and logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -100,8 +100,9 @@ jobs:
           make 2>&1 | tee build.log
       - name: Verify scastd --help
         run: |
-          set -o pipefail
-          ./src/scastd --help 2>&1 | tee scastd-help.log
+          set -e
+          ./src/scastd --help > scastd-help.log 2>&1
+          cat scastd-help.log
       - name: Upload build artifacts and logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- run `./src/scastd --help` after building in CI and DEV workflows and capture output for debugging

## Testing
- `./actionlint .github/workflows/ci.yml .github/workflows/dev.yml >/tmp/actionlint.log && cat /tmp/actionlint.log` *(fails: label "debian-12" is unknown)*
- `yamllint .github/workflows/ci.yml .github/workflows/dev.yml >/tmp/yamllint.log && cat /tmp/yamllint.log`


------
https://chatgpt.com/codex/tasks/task_e_689b7c96f8dc832bade6b6ed1eb5c56b