### PR TITLE
ci: install MySQL connector in Debian and Ubuntu jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
             arch: x64
           - os: ubuntu-24.04
             arch: x64
+          - os: ubuntu-22.04
+            arch: x64
           - os: macos-14
             arch: arm64
     runs-on: ${{ matrix.os }}
@@ -28,20 +30,39 @@ jobs:
         run: |
           curl -sS http://localhost
       - name: Install dependencies (Debian/Ubuntu)
-        if: contains('debian-12 debian-13 ubuntu-24.04', matrix.os)
+        if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.os)
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
             autoconf automake libtool pkg-config \
             libxml2-dev libcurl4-openssl-dev \
-            libmysqlclient-dev mariadb-client libpq-dev libmicrohttpd-dev
-          MYSQL_CFLAGS=$(mysql_config --cflags)
-          MYSQL_LIBS=$(mysql_config --libs)
-          export CPPFLAGS="$MYSQL_CFLAGS $CPPFLAGS"
-          export LDFLAGS="$MYSQL_LIBS $LDFLAGS"
-          PCP=/usr/lib/x86_64-linux-gnu/pkgconfig
-          export PKG_CONFIG_PATH="$PCP:$PKG_CONFIG_PATH"
+            libmysqlclient-dev mariadb-client libpq-dev libmicrohttpd-dev wget
+          if [[ "${{ matrix.os }}" == "debian-12" || "${{ matrix.os }}" == "debian-13" ]]; then
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
+            sudo dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
+            sudo apt-get -f install -y
+          elif [[ "${{ matrix.os }}" == "ubuntu-24.04" ]]; then
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
+            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
+            sudo apt-get -f install -y
+          else
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb
+            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb || true
+            sudo apt-get -f install -y
+          fi
+          INC=/usr/include/mysql-cppconn/jdbc
+          LIB=/usr/lib/x86_64-linux-gnu
+          export CPPFLAGS="-I$INC $CPPFLAGS"
+          export LDFLAGS="-L$LIB $LDFLAGS"
+          export PKG_CONFIG_PATH="$LIB/pkgconfig:$PKG_CONFIG_PATH"
           echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,13 +19,15 @@ jobs:
             arch: x64
           - os: ubuntu-24.04
             arch: x64
+          - os: ubuntu-22.04
+            arch: x64
           - os: macos-14
             arch: arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies (Debian/Ubuntu)
-        if: contains('debian-12 debian-13 ubuntu-24.04', matrix.os)
+        if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.os)
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -34,7 +36,7 @@ jobs:
             gettext \
             autopoint \
             libxml2-dev libcurl4-openssl-dev \
-            libmysqlclient-dev mariadb-client libpq-dev libmicrohttpd-dev
+            libmysqlclient-dev mariadb-client libpq-dev libmicrohttpd-dev wget
           wget https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.tar.gz
           tar -xf gettext-0.22.tar.gz
           cd gettext-0.22
@@ -43,12 +45,31 @@ jobs:
           sudo make install
           cd ..
           echo "PATH=/usr/local/bin:$PATH" >> $GITHUB_ENV
-          MYSQL_CFLAGS=$(mysql_config --cflags)
-          MYSQL_LIBS=$(mysql_config --libs)
-          export CPPFLAGS="$MYSQL_CFLAGS $CPPFLAGS"
-          export LDFLAGS="$MYSQL_LIBS $LDFLAGS"
-          PCP=/usr/lib/x86_64-linux-gnu/pkgconfig
-          export PKG_CONFIG_PATH="$PCP:$PKG_CONFIG_PATH"
+          if [[ "${{ matrix.os }}" == "debian-12" || "${{ matrix.os }}" == "debian-13" ]]; then
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
+            sudo dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
+            sudo apt-get -f install -y
+          elif [[ "${{ matrix.os }}" == "ubuntu-24.04" ]]; then
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
+            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
+            sudo apt-get -f install -y
+          else
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb
+            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb || true
+            sudo apt-get -f install -y
+          fi
+          INC=/usr/include/mysql-cppconn/jdbc
+          LIB=/usr/lib/x86_64-linux-gnu
+          export CPPFLAGS="-I$INC $CPPFLAGS"
+          export LDFLAGS="-L$LIB $LDFLAGS"
+          export PKG_CONFIG_PATH="$LIB/pkgconfig:$PKG_CONFIG_PATH"
           echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- install MySQL Connector/C++ 9.4.0 in Debian and Ubuntu CI jobs
- add Ubuntu 22.04 runners to CI
- export connector include/lib/pkgconfig paths for builds

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable}}' .github/workflows/ci.yml .github/workflows/dev.yml`
- `make`
- `./src/scastd --help`


------
https://chatgpt.com/codex/tasks/task_e_689b90e327b0832b95728c83104749b6