### PR TITLE
fix: initialize DYLD_LIBRARY_PATH

### DIFF
--- a/.github/actions/setup-mysql-connector/action.yml
+++ b/.github/actions/setup-mysql-connector/action.yml
@@ -29,6 +29,7 @@ runs:
         export CPPFLAGS="-I$CONN_DIR/include $CPPFLAGS"
         export LDFLAGS="-L$CONN_DIR/$LIBDIR $LDFLAGS"
         export PKG_CONFIG_PATH="$CONN_DIR/$LIBDIR/pkgconfig:$PKG_CONFIG_PATH"
+        DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}"
         export DYLD_LIBRARY_PATH="$CONN_DIR/$LIBDIR:$DYLD_LIBRARY_PATH"
         echo "PATH=$PATH" >> $GITHUB_ENV
         echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- initialize DYLD_LIBRARY_PATH in MySQL connector setup action
- persist DYLD_LIBRARY_PATH in GITHUB_ENV for later steps

## Testing
- `./autogen.sh`
- `./configure`
- `make`
- `./src/scastd --help`
- `make check`
- `act -j test -P macos-14=ghcr.io/catthehacker/ubuntu:act-latest --matrix os=macos-14,arch=arm64` *(fails: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_689b9318c9d8832b8ebe3034358c1d59