### PR TITLE
ci: make sudo optional in Debian installs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Install dependencies (Debian/Ubuntu)
         if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.label)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          SUDO=""
+          command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+          $SUDO apt-get update
+          $SUDO apt-get install -y \
             build-essential \
             autoconf automake libtool pkg-config \
             gettext \
@@ -53,7 +55,7 @@ jobs:
           cd gettext-0.22
           ./configure --disable-shared
           make -j$(nproc)
-          sudo make install
+          $SUDO make install
           cd ..
           echo "PATH=/usr/local/bin:$PATH" >> $GITHUB_ENV
           if [[ "${{ matrix.label }}" == "debian-12" || "${{ matrix.label }}" == "debian-13" ]]; then
@@ -61,20 +63,20 @@ jobs:
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
-            sudo dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
-            sudo apt-get -f install -y
+            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
+            $SUDO apt-get -f install -y
           elif [[ "${{ matrix.label }}" == "ubuntu-24.04" ]]; then
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
-            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
-            sudo apt-get -f install -y
+            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
+            $SUDO apt-get -f install -y
           else
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb
-            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb || true
-            sudo apt-get -f install -y
+            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb || true
+            $SUDO apt-get -f install -y
           fi
           INC=/usr/include/mysql-cppconn/jdbc
           LIB=/usr/lib/x86_64-linux-gnu

--- a/.github/workflows/future.yml
+++ b/.github/workflows/future.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Install dependencies (Debian/Ubuntu)
         if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.label)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          SUDO=""
+          command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+          $SUDO apt-get update
+          $SUDO apt-get install -y \
             build-essential \
             autoconf automake libtool pkg-config \
             gettext \
@@ -53,7 +55,7 @@ jobs:
           cd gettext-0.22
           ./configure --disable-shared
           make -j$(nproc)
-          sudo make install
+          $SUDO make install
           cd ..
           echo "PATH=/usr/local/bin:$PATH" >> $GITHUB_ENV
           if [[ "${{ matrix.label }}" == "debian-12" || "${{ matrix.label }}" == "debian-13" ]]; then
@@ -61,20 +63,20 @@ jobs:
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
-            sudo dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
-            sudo apt-get -f install -y
+            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
+            $SUDO apt-get -f install -y
           elif [[ "${{ matrix.label }}" == "ubuntu-24.04" ]]; then
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
-            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
-            sudo apt-get -f install -y
+            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
+            $SUDO apt-get -f install -y
           else
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb
-            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb || true
-            sudo apt-get -f install -y
+            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb || true
+            $SUDO apt-get -f install -y
           fi
           INC=/usr/include/mysql-cppconn/jdbc
           LIB=/usr/lib/x86_64-linux-gnu

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -43,8 +43,10 @@ jobs:
       - name: Install dependencies (Debian/Ubuntu)
         if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.label)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          SUDO=""
+          command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+          $SUDO apt-get update
+          $SUDO apt-get install -y \
             build-essential \
             autoconf automake libtool pkg-config \
             libxml2-dev libcurl4-openssl-dev \
@@ -54,20 +56,20 @@ jobs:
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
-            sudo dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
-            sudo apt-get -f install -y
+            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
+            $SUDO apt-get -f install -y
           elif [[ "${{ matrix.label }}" == "ubuntu-24.04" ]]; then
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
-            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
-            sudo apt-get -f install -y
+            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
+            $SUDO apt-get -f install -y
           else
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb
-            sudo dpkg -i libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb || true
-            sudo apt-get -f install -y
+            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb || true
+            $SUDO apt-get -f install -y
           fi
           INC=/usr/include/mysql-cppconn/jdbc
           LIB=/usr/lib/x86_64-linux-gnu


### PR DESCRIPTION
## Summary
- allow Debian-based workflow steps to run without sudo by detecting sudo availability

## Testing
- `python -m yamllint .github/workflows/dev.yml .github/workflows/future.yml .github/workflows/prod.yaml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_689ba5882980832b80384b08bc4d895c