### PR TITLE
ci: unify distro matrix

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,36 +9,29 @@ name: DevelopmentBuildPipeline
 
 jobs:
   test:
-    name: Build and test
+    name: Build and test (${{ matrix.distro }})
     strategy:
       matrix:
+        distro: [debian-12, debian-13, ubuntu-24.04, ubuntu-22.04, macos-14]
         include:
-          - os: ubuntu-22.04
-            arch: x64
+          - distro: debian-12
+            os: ubuntu-22.04
             container: debian:12
-            label: debian-12
-          - os: ubuntu-22.04
-            arch: x64
+          - distro: debian-13
+            os: ubuntu-22.04
             container: debian:trixie
-            label: debian-13
-          - os: ubuntu-24.04
-            arch: x64
-            container: null
-            label: ubuntu-24.04
-          - os: ubuntu-22.04
-            arch: x64
-            container: null
-            label: ubuntu-22.04
-          - os: macos-14
-            arch: arm64
-            container: null
-            label: macos-14
+          - distro: ubuntu-24.04
+            os: ubuntu-24.04
+          - distro: ubuntu-22.04
+            os: ubuntu-22.04
+          - distro: macos-14
+            os: macos-14
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies (Debian/Ubuntu)
-        if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.label)
+        if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.distro)
         run: |
           SUDO=""
           command -v sudo >/dev/null 2>&1 && SUDO="sudo"
@@ -58,14 +51,14 @@ jobs:
           $SUDO make install
           cd ..
           echo "PATH=/usr/local/bin:$PATH" >> $GITHUB_ENV
-          if [[ "${{ matrix.label }}" == "debian-12" || "${{ matrix.label }}" == "debian-13" ]]; then
+          if [[ "${{ matrix.distro }}" == "debian-12" || "${{ matrix.distro }}" == "debian-13" ]]; then
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
             $SUDO dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
             $SUDO apt-get -f install -y
-          elif [[ "${{ matrix.label }}" == "ubuntu-24.04" ]]; then
+          elif [[ "${{ matrix.distro }}" == "ubuntu-24.04" ]]; then
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
@@ -87,7 +80,7 @@ jobs:
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Install dependencies (macOS)
-        if: matrix.label == 'macos-14'
+        if: matrix.distro == 'macos-14'
         run: |
           brew update
           brew install \
@@ -106,12 +99,12 @@ jobs:
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Setup MySQL Connector
-        if: matrix.label == 'macos-14'
+        if: matrix.distro == 'macos-14'
         uses: ./.github/actions/setup-mysql-connector
         with:
           version: mysql-connector-c++-9.4.0-macos15-arm64
       - name: Show environment variables
-        if: matrix.label == 'macos-14'
+        if: matrix.distro == 'macos-14'
         run: |
           echo "PATH=$PATH"
           echo "CPPFLAGS=$CPPFLAGS"
@@ -141,7 +134,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.label }}-${{ matrix.arch }}-logs
+          name: ${{ matrix.distro }}-logs
           path: |
             autogen.log
             configure.log

--- a/.github/workflows/future.yml
+++ b/.github/workflows/future.yml
@@ -9,36 +9,29 @@ name: FutureBuildPipeline
 
 jobs:
   test:
-    name: Build and test
+    name: Build and test (${{ matrix.distro }})
     strategy:
       matrix:
+        distro: [debian-12, debian-13, ubuntu-24.04, ubuntu-22.04, macos-14]
         include:
-          - os: ubuntu-22.04
-            arch: x64
+          - distro: debian-12
+            os: ubuntu-22.04
             container: debian:12
-            label: debian-12
-          - os: ubuntu-22.04
-            arch: x64
+          - distro: debian-13
+            os: ubuntu-22.04
             container: debian:trixie
-            label: debian-13
-          - os: ubuntu-24.04
-            arch: x64
-            container: null
-            label: ubuntu-24.04
-          - os: ubuntu-22.04
-            arch: x64
-            container: null
-            label: ubuntu-22.04
-          - os: macos-14
-            arch: arm64
-            container: null
-            label: macos-14
+          - distro: ubuntu-24.04
+            os: ubuntu-24.04
+          - distro: ubuntu-22.04
+            os: ubuntu-22.04
+          - distro: macos-14
+            os: macos-14
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies (Debian/Ubuntu)
-        if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.label)
+        if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.distro)
         run: |
           SUDO=""
           command -v sudo >/dev/null 2>&1 && SUDO="sudo"
@@ -58,14 +51,14 @@ jobs:
           $SUDO make install
           cd ..
           echo "PATH=/usr/local/bin:$PATH" >> $GITHUB_ENV
-          if [[ "${{ matrix.label }}" == "debian-12" || "${{ matrix.label }}" == "debian-13" ]]; then
+          if [[ "${{ matrix.distro }}" == "debian-12" || "${{ matrix.distro }}" == "debian-13" ]]; then
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
             $SUDO dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
             $SUDO apt-get -f install -y
-          elif [[ "${{ matrix.label }}" == "ubuntu-24.04" ]]; then
+          elif [[ "${{ matrix.distro }}" == "ubuntu-24.04" ]]; then
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
@@ -87,7 +80,7 @@ jobs:
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Install dependencies (macOS)
-        if: matrix.label == 'macos-14'
+        if: matrix.distro == 'macos-14'
         run: |
           brew update
           brew install \
@@ -106,12 +99,12 @@ jobs:
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Setup MySQL Connector
-        if: matrix.label == 'macos-14'
+        if: matrix.distro == 'macos-14'
         uses: ./.github/actions/setup-mysql-connector
         with:
           version: mysql-connector-c++-9.4.0-macos15-arm64
       - name: Show environment variables
-        if: matrix.label == 'macos-14'
+        if: matrix.distro == 'macos-14'
         run: |
           echo "PATH=$PATH"
           echo "CPPFLAGS=$CPPFLAGS"
@@ -141,7 +134,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.label }}-${{ matrix.arch }}-logs
+          name: ${{ matrix.distro }}-logs
           path: |
             autogen.log
             configure.log

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -9,30 +9,23 @@ name: ProductionBuildDeployment
 
 jobs:
   test:
-    name: Build and test
+    name: Build and test (${{ matrix.distro }})
     strategy:
       matrix:
+        distro: [debian-12, debian-13, ubuntu-24.04, ubuntu-22.04, macos-14]
         include:
-          - os: ubuntu-22.04
-            arch: x64
+          - distro: debian-12
+            os: ubuntu-22.04
             container: debian:12
-            label: debian-12
-          - os: ubuntu-22.04
-            arch: x64
+          - distro: debian-13
+            os: ubuntu-22.04
             container: debian:trixie
-            label: debian-13
-          - os: ubuntu-24.04
-            arch: x64
-            container: null
-            label: ubuntu-24.04
-          - os: ubuntu-22.04
-            arch: x64
-            container: null
-            label: ubuntu-22.04
-          - os: macos-14
-            arch: arm64
-            container: null
-            label: macos-14
+          - distro: ubuntu-24.04
+            os: ubuntu-24.04
+          - distro: ubuntu-22.04
+            os: ubuntu-22.04
+          - distro: macos-14
+            os: macos-14
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
@@ -41,7 +34,7 @@ jobs:
         run: |
           curl -sS http://localhost
       - name: Install dependencies (Debian/Ubuntu)
-        if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.label)
+        if: contains('debian-12 debian-13 ubuntu-24.04 ubuntu-22.04', matrix.distro)
         run: |
           SUDO=""
           command -v sudo >/dev/null 2>&1 && SUDO="sudo"
@@ -51,14 +44,14 @@ jobs:
             autoconf automake libtool pkg-config \
             libxml2-dev libcurl4-openssl-dev \
             libmysqlclient-dev mariadb-client libpq-dev libmicrohttpd-dev wget
-          if [[ "${{ matrix.label }}" == "debian-12" || "${{ matrix.label }}" == "debian-13" ]]; then
+          if [[ "${{ matrix.distro }}" == "debian-12" || "${{ matrix.distro }}" == "debian-13" ]]; then
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
             $SUDO dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
             $SUDO apt-get -f install -y
-          elif [[ "${{ matrix.label }}" == "ubuntu-24.04" ]]; then
+          elif [[ "${{ matrix.distro }}" == "ubuntu-24.04" ]]; then
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
@@ -80,7 +73,7 @@ jobs:
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Install dependencies (macOS)
-        if: matrix.label == 'macos-14'
+        if: matrix.distro == 'macos-14'
         run: |
           brew update
           brew install \
@@ -99,7 +92,7 @@ jobs:
           echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Setup MySQL Connector
-        if: matrix.label == 'macos-14'
+        if: matrix.distro == 'macos-14'
         uses: ./.github/actions/setup-mysql-connector
         with:
           version: mysql-connector-c++-9.4.0-macos15-arm64
@@ -124,7 +117,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.label }}-${{ matrix.arch }}-logs
+          name: ${{ matrix.distro }}-logs
           path: |
             autogen.log
             configure.log


### PR DESCRIPTION
## Summary
- center workflow matrices on `distro` to simplify OS selection
- ensure each build job is uniquely named per distro

## Testing
- `yamllint -d "{extends: default, rules: {line-length: {max: 500}}}" .github/workflows/dev.yml .github/workflows/future.yml .github/workflows/prod.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689baa859edc832ba6a67514940f95ad