### PR TITLE
Ensure matrix jobs continue after failure

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Build and test (${{ matrix.distro }})
     strategy:
+      fail-fast: false
       matrix:
         distro: [debian-12, debian-13, ubuntu-24.04, ubuntu-22.04, macos-14]
         include:

--- a/.github/workflows/future.yml
+++ b/.github/workflows/future.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Build and test (${{ matrix.distro }})
     strategy:
+      fail-fast: false
       matrix:
         distro: [debian-12, debian-13, ubuntu-24.04, ubuntu-22.04, macos-14]
         include:

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Build and test (${{ matrix.distro }})
     strategy:
+      fail-fast: false
       matrix:
         distro: [debian-12, debian-13, ubuntu-24.04, ubuntu-22.04, macos-14]
         include:


### PR DESCRIPTION
## Summary
- keep matrix jobs running even when one fails by disabling fail-fast in dev, future, and prod workflows

## Testing
- `./autogen.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689bac275310832bb5697ca8310a7dc0