### PR TITLE
Remove HTTP request test step from production workflow

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -30,9 +30,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
-      - name: Test HTTP request
-        run: |
-          curl -sS http://localhost
       - uses: ./.github/actions/build-and-test
         with:
           distro: ${{ matrix.distro }}


### PR DESCRIPTION
## Summary
- remove curl step from prod workflow to avoid failures when no service is running

## Testing
- `yamllint .github/workflows/prod.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689baf8fb584832bbf8ccfd60771c050