### PR TITLE
feat: default to console logging in foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ SCASTD reads settings from configuration files that support environment variable
 - **[scastd.conf](scastd.conf)** - Main configuration file with comprehensive settings
 - **[scastd_pg.conf](scastd_pg.conf)** - PostgreSQL-specific configuration example
 
+Console logging is enabled by default when SCASTD runs in the foreground. Running with `--daemon` disables console output unless `log_console true` is set in the configuration. Set `log_console false` to silence console logs even in foreground mode.
+
 ### Environment Variable Integration
 
 We implement robust environment variable support for sensitive data and containerized deployments:

--- a/scastd.conf
+++ b/scastd.conf
@@ -1,8 +1,9 @@
 # Sample scastd configuration
 # Lines starting with # are comments
 # Run scastd in the foreground by default. Use --daemon to run in the
-# background; when daemonized, the PID is written to /var/run/scastd.pid
-# and console logging is disabled.
+# background; when daemonized, the PID is written to /var/run/scastd.pid.
+# Console logging is enabled by default when running in the foreground
+# and disabled when daemonized. Set log_console to override.
 username root
 password secret
 DatabaseType mysql
@@ -44,6 +45,9 @@ error_log error.log
 debug_log debug.log
 # Debug verbosity level (1-4)
 debug_level 1
+# Enable console logging (default: true when foreground)
+# Set to false to disable console output
+# log_console true
 # Optional syslog output
 syslog_enabled false
 syslog_host localhost

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -261,7 +261,7 @@ int main(int argc, char **argv) {
     }
 
     if (doDump) {
-        return scastd::dumpDatabase(configPath, overrides, dumpDir);
+        return scastd::dumpDatabase(configPath, overrides, dumpDir, !daemonMode);
     }
 
     if (daemonMode) {
@@ -277,5 +277,5 @@ int main(int argc, char **argv) {
         }
     }
 
-    return scastd::run(configPath, overrides);
+    return scastd::run(configPath, overrides, !daemonMode);
 }

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -176,7 +176,8 @@ bool setupDatabase(const std::string &dbType, IDatabase *db) {
 
 int dumpDatabase(const std::string &configPath,
                  const std::map<std::string, std::string> &overrides,
-                 const std::string &dumpDir) {
+                 const std::string &dumpDir,
+                 bool defaultConsoleLog) {
         init_i18n();
         Config cfg;
         if (!cfg.Load(configPath)) {
@@ -191,7 +192,7 @@ int dumpDatabase(const std::string &configPath,
         bool loggingEnabled = true;
         logger.setLogDir(logDir);
         logger.setLogFiles(cfg.AccessLog(), cfg.ErrorLog(), cfg.DebugLog());
-        logger.setConsoleOutput(cfg.Get("log_console", false));
+        logger.setConsoleOutput(cfg.Get("log_console", defaultConsoleLog));
         logger.setDebugLevel(cfg.DebugLevel());
         logger.setRotation(cfg.LogMaxSize(), cfg.LogRetention());
         statusLogger.setPath(logDir + "/status.json");
@@ -404,7 +405,8 @@ void sigHUP(int sig)
 
 
 int run(const std::string &configPath,
-        const std::map<std::string, std::string> &overrides)
+        const std::map<std::string, std::string> &overrides,
+        bool defaultConsoleLog)
 {
         init_i18n();
         scastd::HttpServer httpServer;
@@ -427,7 +429,7 @@ int run(const std::string &configPath,
         std::string accessLog = cfg.AccessLog();
         std::string errorLog = cfg.ErrorLog();
         std::string debugLog = cfg.DebugLog();
-        bool consoleFlag = cfg.Get("log_console", false);
+        bool consoleFlag = cfg.Get("log_console", defaultConsoleLog);
         int debugLevel = cfg.DebugLevel();
         std::string logDir = cfg.Get("log_dir", "./logs");
         bool loggingEnabled = true;
@@ -588,7 +590,7 @@ int run(const std::string &configPath,
                                 std::string newAccess = cfg.AccessLog();
                                 std::string newError = cfg.ErrorLog();
                                 std::string newDebug = cfg.DebugLog();
-                                bool newConsole = cfg.Get("log_console", false);
+                                bool newConsole = cfg.Get("log_console", consoleFlag);
                                 int newDebugLevel = cfg.DebugLevel();
                                 if (newAccess != accessLog || newError != errorLog || newDebug != debugLog) {
                                         accessLog = newAccess;

--- a/src/scastd.h
+++ b/src/scastd.h
@@ -29,10 +29,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 namespace scastd {
 int run(const std::string &configPath,
-        const std::map<std::string, std::string> &overrides);
+        const std::map<std::string, std::string> &overrides,
+        bool defaultConsoleLog);
 int dumpDatabase(const std::string &configPath,
                  const std::map<std::string, std::string> &overrides,
-                 const std::string &dumpDir);
+                 const std::string &dumpDir,
+                 bool defaultConsoleLog);
 bool setupDatabase(const std::string &dbType, IDatabase *db);
 }
 


### PR DESCRIPTION
## Summary
- default to console logging when not daemonized and allow config to override
- document console logging behavior in sample config and README

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_689d7b4745f0832b8ec95a4a3f12c3b6