### PR TITLE
Use system log directory by default

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -7,7 +7,7 @@ absolute or relative to `log_dir`.
 
 | Key | Default | Description |
 | --- | --- | --- |
-| `log_dir` | `./logs` | Directory where log files are stored. |
+| `log_dir` | `/var/log/scastd` | Directory where log files are stored. |
 | `access_log` | `access.log` | File receiving HTTP access entries. |
 | `error_log` | `error.log` | File receiving error messages. |
 | `debug_log` | `debug.log` | File receiving debug output. |
@@ -23,7 +23,7 @@ local log files in addition to being sent to the remote server.
 ## Status Log
 
 Scastd appends structured status entries to `status.json` inside
-`log_dir` (default `./logs/status.json`).
+`log_dir` (default `/var/log/scastd/status.json`).
 Each line is a JSON object with the following schema:
 
 | Field | Description |

--- a/scastd.conf
+++ b/scastd.conf
@@ -36,7 +36,7 @@ poll_interval 5m
 
 # Logging configuration
 # Directory for log files
-log_dir ./logs
+log_dir /var/log/scastd
 # Maximum size of a log file in bytes before rotation
 log_max_size 1048576
 # Number of rotated log files to keep

--- a/scastd_pg.conf
+++ b/scastd_pg.conf
@@ -16,7 +16,7 @@ dbname scastd
 sslmode require
 
 # Logging configuration
-log_dir ./logs
+log_dir /var/log/scastd
 log_max_size 1048576
 log_retention 5
 access_log access.log

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -194,19 +194,19 @@ static std::string combine_log_path(const std::string &dir, const std::string &p
 }
 
 std::string Config::AccessLog() const {
-    std::string dir = Get("log_dir", "./logs");
+    std::string dir = Get("log_dir", "/var/log/scastd");
     std::string path = Get("access_log", "access.log");
     return combine_log_path(dir, path);
 }
 
 std::string Config::ErrorLog() const {
-    std::string dir = Get("log_dir", "./logs");
+    std::string dir = Get("log_dir", "/var/log/scastd");
     std::string path = Get("error_log", "error.log");
     return combine_log_path(dir, path);
 }
 
 std::string Config::DebugLog() const {
-    std::string dir = Get("log_dir", "./logs");
+    std::string dir = Get("log_dir", "/var/log/scastd");
     std::string path = Get("debug_log", "debug.log");
     return combine_log_path(dir, path);
 }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "logger.h"
 
 #include <filesystem>
+#include <system_error>
 #include <iostream>
 #include <netdb.h>
 #include <sys/socket.h>
@@ -59,6 +60,14 @@ void Logger::setLogFiles(const std::string &accessFile,
 }
 
 void Logger::setLogDir(const std::string &directory) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::create_directories(directory, ec);
+    fs::permissions(directory,
+                    fs::perms::owner_read | fs::perms::owner_write |
+                        fs::perms::owner_exec | fs::perms::group_read |
+                        fs::perms::group_exec,
+                    fs::perm_options::replace, ec);
     setLogFiles(directory + "/access.log",
                 directory + "/error.log",
                 directory + "/debug.log");

--- a/src/scastd.cpp
+++ b/src/scastd.cpp
@@ -190,7 +190,7 @@ int dumpDatabase(const std::string &configPath,
         for (const auto &kv : overrides) {
                 cfg.Set(kv.first, kv.second);
         }
-        std::string logDir = cfg.Get("log_dir", "./logs");
+        std::string logDir = cfg.Get("log_dir", "/var/log/scastd");
         bool loggingEnabled = true;
         logger.setLogDir(logDir);
         logger.setLogFiles(cfg.AccessLog(), cfg.ErrorLog(), cfg.DebugLog());
@@ -436,7 +436,7 @@ int run(const std::string &configPath,
         std::string debugLog = cfg.DebugLog();
         bool consoleFlag = cfg.Get("log_console", defaultConsoleLog);
         int debugLevel = cfg.DebugLevel();
-        std::string logDir = cfg.Get("log_dir", "./logs");
+        std::string logDir = cfg.Get("log_dir", "/var/log/scastd");
         bool loggingEnabled = true;
         logger.setLogDir(logDir);
         logger.setLogFiles(accessLog, errorLog, debugLog);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) @mysqlclient_CFLAGS@ -DTEST_SRCDIR=\"$(top_srcdir)\"
 
 check_PROGRAMS = unit_tests
-unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp \
+unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp test_logger.cpp \
     ../src/Config.cpp ../src/HttpServer.cpp ../src/icecast2.cpp ../src/UrlParser.cpp \
     ../src/CurlClient.cpp ../src/logger.cpp ../src/StatusLogger.cpp ../src/scastd.cpp \
     ../src/db/MySQLDatabase.cpp ../src/db/MariaDBDatabase.cpp \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -112,11 +112,12 @@ am_unit_tests_OBJECTS = test_main.$(OBJEXT) test_config.$(OBJEXT) \
 	test_sql.$(OBJEXT) test_http.$(OBJEXT) test_icecast.$(OBJEXT) \
 	test_url_parser.$(OBJEXT) test_db_invalid.$(OBJEXT) \
 	test_setupdb.$(OBJEXT) test_missing_config.$(OBJEXT) \
-	test_pid.$(OBJEXT) ../src/Config.$(OBJEXT) \
-	../src/HttpServer.$(OBJEXT) ../src/icecast2.$(OBJEXT) \
-	../src/UrlParser.$(OBJEXT) ../src/CurlClient.$(OBJEXT) \
-	../src/logger.$(OBJEXT) ../src/StatusLogger.$(OBJEXT) \
-	../src/scastd.$(OBJEXT) ../src/db/MySQLDatabase.$(OBJEXT) \
+	test_pid.$(OBJEXT) test_logger.$(OBJEXT) \
+	../src/Config.$(OBJEXT) ../src/HttpServer.$(OBJEXT) \
+	../src/icecast2.$(OBJEXT) ../src/UrlParser.$(OBJEXT) \
+	../src/CurlClient.$(OBJEXT) ../src/logger.$(OBJEXT) \
+	../src/StatusLogger.$(OBJEXT) ../src/scastd.$(OBJEXT) \
+	../src/db/MySQLDatabase.$(OBJEXT) \
 	../src/db/MariaDBDatabase.$(OBJEXT) \
 	../src/db/PostgresDatabase.$(OBJEXT) stubs.$(OBJEXT)
 unit_tests_OBJECTS = $(am_unit_tests_OBJECTS)
@@ -151,9 +152,10 @@ am__depfiles_remade = ../src/$(DEPDIR)/Config.Po \
 	../src/db/$(DEPDIR)/PostgresDatabase.Po ./$(DEPDIR)/stubs.Po \
 	./$(DEPDIR)/test_config.Po ./$(DEPDIR)/test_db_invalid.Po \
 	./$(DEPDIR)/test_http.Po ./$(DEPDIR)/test_icecast.Po \
-	./$(DEPDIR)/test_main.Po ./$(DEPDIR)/test_missing_config.Po \
-	./$(DEPDIR)/test_pid.Po ./$(DEPDIR)/test_setupdb.Po \
-	./$(DEPDIR)/test_sql.Po ./$(DEPDIR)/test_url_parser.Po
+	./$(DEPDIR)/test_logger.Po ./$(DEPDIR)/test_main.Po \
+	./$(DEPDIR)/test_missing_config.Po ./$(DEPDIR)/test_pid.Po \
+	./$(DEPDIR)/test_setupdb.Po ./$(DEPDIR)/test_sql.Po \
+	./$(DEPDIR)/test_url_parser.Po
 am__mv = mv -f
 CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
@@ -566,7 +568,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) @mysqlclient_CFLAGS@ -DTEST_SRCDIR=\"$(top_srcdir)\"
-unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp \
+unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp test_logger.cpp \
     ../src/Config.cpp ../src/HttpServer.cpp ../src/icecast2.cpp ../src/UrlParser.cpp \
     ../src/CurlClient.cpp ../src/logger.cpp ../src/StatusLogger.cpp ../src/scastd.cpp \
     ../src/db/MySQLDatabase.cpp ../src/db/MariaDBDatabase.cpp \
@@ -678,6 +680,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_db_invalid.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_http.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_icecast.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_logger.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_main.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_missing_config.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_pid.Po@am__quote@ # am--include-marker
@@ -1033,6 +1036,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/test_db_invalid.Po
 	-rm -f ./$(DEPDIR)/test_http.Po
 	-rm -f ./$(DEPDIR)/test_icecast.Po
+	-rm -f ./$(DEPDIR)/test_logger.Po
 	-rm -f ./$(DEPDIR)/test_main.Po
 	-rm -f ./$(DEPDIR)/test_missing_config.Po
 	-rm -f ./$(DEPDIR)/test_pid.Po
@@ -1100,6 +1104,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/test_db_invalid.Po
 	-rm -f ./$(DEPDIR)/test_http.Po
 	-rm -f ./$(DEPDIR)/test_icecast.Po
+	-rm -f ./$(DEPDIR)/test_logger.Po
 	-rm -f ./$(DEPDIR)/test_main.Po
 	-rm -f ./$(DEPDIR)/test_missing_config.Po
 	-rm -f ./$(DEPDIR)/test_pid.Po

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -43,6 +43,20 @@ TEST_CASE("Config parsing") {
     std::remove(fname);
 }
 
+TEST_CASE("Logging defaults use system log directory") {
+    const char* fname = "empty.conf";
+    std::ofstream out(fname);
+    out.close();
+
+    Config cfg;
+    REQUIRE(cfg.Load(fname));
+    REQUIRE(cfg.AccessLog() == std::string("/var/log/scastd/access.log"));
+    REQUIRE(cfg.ErrorLog() == std::string("/var/log/scastd/error.log"));
+    REQUIRE(cfg.DebugLog() == std::string("/var/log/scastd/debug.log"));
+
+    std::remove(fname);
+}
+
 TEST_CASE("Environment and secret overrides") {
     const char* cfg = "test.conf";
     std::ofstream out(cfg);

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -1,0 +1,47 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "catch.hpp"
+#include "../src/logger.h"
+#include <filesystem>
+
+TEST_CASE("setLogDir creates directory with safe permissions") {
+    namespace fs = std::filesystem;
+    fs::path base = fs::temp_directory_path() / "scastd-logdir-test";
+    fs::remove_all(base);
+
+    Logger logger(false);
+    logger.setLogDir(base.string());
+
+    REQUIRE(fs::exists(base));
+    fs::perms p = fs::status(base).permissions();
+    REQUIRE((p & fs::perms::owner_read) != fs::perms::none);
+    REQUIRE((p & fs::perms::owner_write) != fs::perms::none);
+    REQUIRE((p & fs::perms::owner_exec) != fs::perms::none);
+    REQUIRE((p & fs::perms::group_read) != fs::perms::none);
+    REQUIRE((p & fs::perms::group_exec) != fs::perms::none);
+    REQUIRE((p & fs::perms::group_write) == fs::perms::none);
+    REQUIRE((p & (fs::perms::others_read | fs::perms::others_write |
+                  fs::perms::others_exec)) == fs::perms::none);
+
+    fs::remove_all(base);
+}


### PR DESCRIPTION
## Summary
- Default log directory is `/var/log/scastd` and sample configs/docs updated
- Logger now ensures `setLogDir` creates directories with restrictive permissions
- Added tests covering new defaults and log directory permissions

## Testing
- `./autogen.sh`
- `./configure`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_689e553720f0832b88be65848eb3d300