### PR TITLE
Add Icecast credentials env vars and integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,13 @@ export SCASTD_USERNAME="statistics_user"
 export SCASTD_PASSWORD_FILE="/run/secrets/db_password"
 export SCASTD_DATABASE_HOST="mysql-cluster.internal"
 export SCASTD_API_TOKEN_SECRET="your-jwt-secret-here"
+export ICEADMINUSER="admin"
+export ICEUSERPASS="hackme"
 ```
+
+These credentials configure access to the Icecast administrative interface. If
+`ICEADMINUSER` or `ICEUSERPASS` are not provided, the daemon falls back to the
+legacy `SCASTD_ADMINUSER` and `SCASTD_USERPASS` variables.
 
 For detailed configuration instructions, please refer to our comprehensive [Installation Guide](INSTALL.md).
 

--- a/docs/Icecast2.md
+++ b/docs/Icecast2.md
@@ -30,3 +30,17 @@ int main() {
 
 The `fetchStats` method returns a vector of `StreamInfo` structures which can be
 used by the existing database layer to record real‑time stream statistics.
+
+## Configuration
+
+The Icecast statistics client reads credentials from the environment. For
+backward compatibility the daemon checks the legacy `SCASTD_*` variables if the
+new names are not set:
+
+| Variable | Description | Fallback |
+| -------- | ----------- | -------- |
+| `ICEADMINUSER` | Username for the Icecast admin interface | `SCASTD_ADMINUSER` |
+| `ICEUSERPASS` | Password for the admin user | `SCASTD_USERPASS` |
+
+These values are used when establishing the HTTP connection to
+`/admin/stats.xml`.

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -92,6 +92,21 @@ bool Config::Load(const std::string &path) {
         values["password"] = env;
     }
 
+    env = std::getenv("ICEADMINUSER");
+    if (!env) {
+        env = std::getenv("SCASTD_ADMINUSER");
+    }
+    if (env) {
+        values["iceadminuser"] = env;
+    }
+    env = std::getenv("ICEUSERPASS");
+    if (!env) {
+        env = std::getenv("SCASTD_USERPASS");
+    }
+    if (env) {
+        values["iceuserpass"] = env;
+    }
+
     env = std::getenv("SCASTD_THREAD_COUNT");
     if (env) {
         values["thread_count"] = env;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) @mysqlclient_CFLAGS@ -DTEST_SRCDIR=\"$(top_srcdir)\"
 
 check_PROGRAMS = unit_tests
-unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp test_logger.cpp \
+unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_icecast_dev.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp test_logger.cpp \
     ../src/Config.cpp ../src/HttpServer.cpp ../src/icecast2.cpp ../src/UrlParser.cpp \
     ../src/CurlClient.cpp ../src/logger.cpp ../src/StatusLogger.cpp ../src/scastd.cpp \
     ../src/db/MySQLDatabase.cpp ../src/db/MariaDBDatabase.cpp \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -110,14 +110,14 @@ CONFIG_CLEAN_VPATH_FILES =
 am__dirstamp = $(am__leading_dot)dirstamp
 am_unit_tests_OBJECTS = test_main.$(OBJEXT) test_config.$(OBJEXT) \
 	test_sql.$(OBJEXT) test_http.$(OBJEXT) test_icecast.$(OBJEXT) \
-	test_url_parser.$(OBJEXT) test_db_invalid.$(OBJEXT) \
-	test_setupdb.$(OBJEXT) test_missing_config.$(OBJEXT) \
-	test_pid.$(OBJEXT) test_logger.$(OBJEXT) \
-	../src/Config.$(OBJEXT) ../src/HttpServer.$(OBJEXT) \
-	../src/icecast2.$(OBJEXT) ../src/UrlParser.$(OBJEXT) \
-	../src/CurlClient.$(OBJEXT) ../src/logger.$(OBJEXT) \
-	../src/StatusLogger.$(OBJEXT) ../src/scastd.$(OBJEXT) \
-	../src/db/MySQLDatabase.$(OBJEXT) \
+	test_icecast_dev.$(OBJEXT) test_url_parser.$(OBJEXT) \
+	test_db_invalid.$(OBJEXT) test_setupdb.$(OBJEXT) \
+	test_missing_config.$(OBJEXT) test_pid.$(OBJEXT) \
+	test_logger.$(OBJEXT) ../src/Config.$(OBJEXT) \
+	../src/HttpServer.$(OBJEXT) ../src/icecast2.$(OBJEXT) \
+	../src/UrlParser.$(OBJEXT) ../src/CurlClient.$(OBJEXT) \
+	../src/logger.$(OBJEXT) ../src/StatusLogger.$(OBJEXT) \
+	../src/scastd.$(OBJEXT) ../src/db/MySQLDatabase.$(OBJEXT) \
 	../src/db/MariaDBDatabase.$(OBJEXT) \
 	../src/db/PostgresDatabase.$(OBJEXT) stubs.$(OBJEXT)
 unit_tests_OBJECTS = $(am_unit_tests_OBJECTS)
@@ -152,10 +152,10 @@ am__depfiles_remade = ../src/$(DEPDIR)/Config.Po \
 	../src/db/$(DEPDIR)/PostgresDatabase.Po ./$(DEPDIR)/stubs.Po \
 	./$(DEPDIR)/test_config.Po ./$(DEPDIR)/test_db_invalid.Po \
 	./$(DEPDIR)/test_http.Po ./$(DEPDIR)/test_icecast.Po \
-	./$(DEPDIR)/test_logger.Po ./$(DEPDIR)/test_main.Po \
-	./$(DEPDIR)/test_missing_config.Po ./$(DEPDIR)/test_pid.Po \
-	./$(DEPDIR)/test_setupdb.Po ./$(DEPDIR)/test_sql.Po \
-	./$(DEPDIR)/test_url_parser.Po
+	./$(DEPDIR)/test_icecast_dev.Po ./$(DEPDIR)/test_logger.Po \
+	./$(DEPDIR)/test_main.Po ./$(DEPDIR)/test_missing_config.Po \
+	./$(DEPDIR)/test_pid.Po ./$(DEPDIR)/test_setupdb.Po \
+	./$(DEPDIR)/test_sql.Po ./$(DEPDIR)/test_url_parser.Po
 am__mv = mv -f
 CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
@@ -568,7 +568,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) @mysqlclient_CFLAGS@ -DTEST_SRCDIR=\"$(top_srcdir)\"
-unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp test_logger.cpp \
+unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_icecast_dev.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp test_logger.cpp \
     ../src/Config.cpp ../src/HttpServer.cpp ../src/icecast2.cpp ../src/UrlParser.cpp \
     ../src/CurlClient.cpp ../src/logger.cpp ../src/StatusLogger.cpp ../src/scastd.cpp \
     ../src/db/MySQLDatabase.cpp ../src/db/MariaDBDatabase.cpp \
@@ -680,6 +680,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_db_invalid.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_http.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_icecast.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_icecast_dev.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_logger.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_main.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_missing_config.Po@am__quote@ # am--include-marker
@@ -1036,6 +1037,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/test_db_invalid.Po
 	-rm -f ./$(DEPDIR)/test_http.Po
 	-rm -f ./$(DEPDIR)/test_icecast.Po
+	-rm -f ./$(DEPDIR)/test_icecast_dev.Po
 	-rm -f ./$(DEPDIR)/test_logger.Po
 	-rm -f ./$(DEPDIR)/test_main.Po
 	-rm -f ./$(DEPDIR)/test_missing_config.Po
@@ -1104,6 +1106,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/test_db_invalid.Po
 	-rm -f ./$(DEPDIR)/test_http.Po
 	-rm -f ./$(DEPDIR)/test_icecast.Po
+	-rm -f ./$(DEPDIR)/test_icecast_dev.Po
 	-rm -f ./$(DEPDIR)/test_logger.Po
 	-rm -f ./$(DEPDIR)/test_main.Po
 	-rm -f ./$(DEPDIR)/test_missing_config.Po

--- a/tests/test_icecast_dev.cpp
+++ b/tests/test_icecast_dev.cpp
@@ -1,0 +1,55 @@
+/*
+/////////////////////////////////////////////////
+// Scast Daemon
+// Authors: oddsock, dstjohn
+/////////////////////////////////////////////////
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "catch.hpp"
+#include "../src/icecast2.h"
+#include "../src/CurlClient.h"
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+TEST_CASE("Fetch stats.xml from dev server") {
+    const char *host = std::getenv("ICECAST_DEV_HOST");
+    const char *portEnv = std::getenv("ICECAST_DEV_PORT");
+    const char *user = std::getenv("ICEADMINUSER");
+    if (!user) {
+        user = std::getenv("SCASTD_ADMINUSER");
+    }
+    const char *pass = std::getenv("ICEUSERPASS");
+    if (!pass) {
+        pass = std::getenv("SCASTD_USERPASS");
+    }
+    if (!host || !user || !pass) {
+        WARN("Missing ICECAST_DEV_HOST or credentials; skipping integration test");
+        return;
+    }
+    int port = portEnv ? std::atoi(portEnv) : 8000;
+
+    CurlClient client;
+    scastd::Icecast2 ice(host, port, user, pass, client);
+    std::vector<scastd::Icecast2::StreamInfo> stats;
+    std::string err;
+    REQUIRE(ice.fetchStats(stats, err));
+    REQUIRE(err.empty());
+    REQUIRE(!stats.empty());
+}
+


### PR DESCRIPTION
## Summary
- read new `ICEADMINUSER` and `ICEUSERPASS` environment variables with fallback to `SCASTD_*`
- document Icecast configuration env vars
- add integration test that fetches `stats.xml` from dev server using credentials

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_689e578befe4832bbd5b4212aaadc87e