### PR TITLE
Add release packaging target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,3 +18,11 @@ permissions_great_again:
 	chmod 755 $(DESTDIR)/etc/scastd
 	chmod 640 $(DESTDIR)/etc/scastd/scastd.conf $(DESTDIR)/etc/scastd/scastd.db
 	chmod 750 $(DESTDIR)/var/log/scastd
+
+# Build platform-specific packages
+release:
+	@case "`uname -s`" in \
+	  Darwin) ./packaging/macos/build_pkg.sh $(VERSION) ;; \
+	  Linux) ./packaging/debian/build_deb.sh $(VERSION) ;; \
+	  *) echo "Unsupported platform: `uname -s`" && exit 1 ;; \
+	esac

--- a/Makefile.in
+++ b/Makefile.in
@@ -884,3 +884,11 @@ permissions_great_again:
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.
 .NOEXPORT:
+
+# Build platform-specific packages
+release:
+	@case "`uname -s`" in \
+	  Darwin) ./packaging/macos/build_pkg.sh $(VERSION) ;; \
+	  Linux) ./packaging/debian/build_deb.sh $(VERSION) ;; \
+	  *) echo "Unsupported platform: `uname -s`" && exit 1 ;; \
+	esac

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -1,5 +1,17 @@
 # Packaging
 
+## Release target
+
+The top-level `Makefile` provides a convenience target that builds a
+platform-appropriate package. Specify the version on the command line:
+
+```bash
+make release VERSION=1.0
+```
+
+On Linux this runs `packaging/debian/build_deb.sh` and produces a `.deb`.
+On macOS it executes `packaging/macos/build_pkg.sh` to generate a `.pkg`.
+
 ## Debian/Ubuntu
 
 The `packaging/debian` directory provides a helper script and systemd unit file.


### PR DESCRIPTION
## Summary
- add `release` target to Makefile for platform packaging
- document unified release process

## Testing
- `./autogen.sh` *(fails: 'aclocal' not found)*
- `./configure` *(fails: cannot find required auxiliary files)*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_689e61833b44832bbedf794ec4f41e3a