### PR TITLE
Add distro-aware Debian packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ src/.deps/
 src/.libs/
 logs/
 
+# Packaging output
+dist/
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,8 @@
 SUBDIRS = src scripts tests
 
+# Default distribution identifier for packaging
+DISTRO ?= bookworm
+
 # Installation of configuration and SQLite database
 install-data-local:
 	$(INSTALL) -d -m 755 $(DESTDIR)/etc/scastd
@@ -23,6 +26,6 @@ permissions_great_again:
 release:
 	@case "`uname -s`" in \
 	  Darwin) ./packaging/macos/build_pkg.sh $(VERSION) ;; \
-	  Linux) ./packaging/debian/build_deb.sh $(VERSION) ;; \
+	  Linux) ./packaging/debian/build_deb.sh $(VERSION) $(DISTRO) ;; \
 	  *) echo "Unsupported platform: `uname -s`" && exit 1 ;; \
 	esac

--- a/Makefile.in
+++ b/Makefile.in
@@ -29,8 +29,8 @@ am__make_running_with_option = \
   case $${target_option-} in \
       ?) ;; \
       *) echo "am__make_running_with_option: internal error: invalid" \
-	      "target option '$${target_option-}' specified" >&2; \
-	 exit 1;; \
+              "target option '$${target_option-}' specified" >&2; \
+         exit 1;; \
   esac; \
   has_opt=no; \
   sane_makeflags=$$MAKEFLAGS; \
@@ -39,9 +39,9 @@ am__make_running_with_option = \
   else \
     case $$MAKEFLAGS in \
       *\\[\ \	]*) \
-	bs=\\; \
-	sane_makeflags=`printf '%s\n' "$$MAKEFLAGS" \
-	  | sed "s/$$bs$$bs[$$bs $$bs	]*//g"`;; \
+        bs=\\; \
+        sane_makeflags=`printf '%s\n' "$$MAKEFLAGS" \
+          | sed "s/$$bs$$bs[$$bs $$bs	]*//g"`;; \
     esac; \
   fi; \
   skip_next=no; \
@@ -53,11 +53,11 @@ am__make_running_with_option = \
     test $$skip_next = yes && { skip_next=no; continue; }; \
     case $$flg in \
       *=*|--*) continue;; \
-	-*I) strip_trailopt 'I'; skip_next=yes;; \
+        -*I) strip_trailopt 'I'; skip_next=yes;; \
       -*I?*) strip_trailopt 'I';; \
-	-*O) strip_trailopt 'O'; skip_next=yes;; \
+        -*O) strip_trailopt 'O'; skip_next=yes;; \
       -*O?*) strip_trailopt 'O';; \
-	-*l) strip_trailopt 'l'; skip_next=yes;; \
+        -*l) strip_trailopt 'l'; skip_next=yes;; \
       -*l?*) strip_trailopt 'l';; \
       -[dEDm]) skip_next=yes;; \
       -[JT]) skip_next=yes;; \
@@ -186,16 +186,16 @@ am__relativize = \
     first=`echo "$$dir1" | sed -e "$$sed_first"`; \
     if test "$$first" != "."; then \
       if test "$$first" = ".."; then \
-	dir2=`echo "$$dir0" | sed -e "$$sed_last"`/"$$dir2"; \
-	dir0=`echo "$$dir0" | sed -e "$$sed_butlast"`; \
+        dir2=`echo "$$dir0" | sed -e "$$sed_last"`/"$$dir2"; \
+        dir0=`echo "$$dir0" | sed -e "$$sed_butlast"`; \
       else \
-	first2=`echo "$$dir2" | sed -e "$$sed_first"`; \
-	if test "$$first2" = "$$first"; then \
-	  dir2=`echo "$$dir2" | sed -e "$$sed_rest"`; \
-	else \
-	  dir2="../$$dir2"; \
-	fi; \
-	dir0="$$dir0"/"$$first"; \
+        first2=`echo "$$dir2" | sed -e "$$sed_first"`; \
+        if test "$$first2" = "$$first"; then \
+          dir2=`echo "$$dir2" | sed -e "$$sed_rest"`; \
+        else \
+          dir2="../$$dir2"; \
+        fi; \
+        dir0="$$dir0"/"$$first"; \
       fi; \
     fi; \
     dir1=`echo "$$dir1" | sed -e "$$sed_rest"`; \
@@ -589,12 +589,12 @@ distdir-am: $(DISTFILES)
 	    echo "     am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)"; \
 	    ($(am__cd) $$subdir && \
 	      $(MAKE) $(AM_MAKEFLAGS) \
-		top_distdir="$$new_top_distdir" \
-		distdir="$$new_distdir" \
+	        top_distdir="$$new_top_distdir" \
+	        distdir="$$new_distdir" \
 		am__remove_distdir=: \
 		am__skip_length_check=: \
 		am__skip_mode_fix=: \
-		distdir) \
+	        distdir) \
 	      || exit 1; \
 	  fi; \
 	done
@@ -634,7 +634,7 @@ dist-tarZ: distdir
 
 dist-shar: distdir
 	@echo WARNING: "Support for shar distribution archives is" \
-		       "deprecated." >&2
+	               "deprecated." >&2
 	@echo WARNING: "It will be removed altogether in Automake 2.0" >&2
 	shar $(distdir) | eval GZIP= gzip $(GZIP_ENV) -c >$(distdir).shar.gz
 	$(am__post_remove_distdir)
@@ -690,14 +690,14 @@ distcheck: dist
 	  && $(MAKE) $(AM_MAKEFLAGS) installcheck \
 	  && $(MAKE) $(AM_MAKEFLAGS) uninstall \
 	  && $(MAKE) $(AM_MAKEFLAGS) distuninstallcheck_dir="$$dc_install_base" \
-		distuninstallcheck \
+	        distuninstallcheck \
 	  && chmod -R a-w "$$dc_install_base" \
 	  && ({ \
 	       (cd ../.. && umask 077 && mkdir "$$dc_destdir") \
 	       && $(MAKE) $(AM_MAKEFLAGS) DESTDIR="$$dc_destdir" install \
 	       && $(MAKE) $(AM_MAKEFLAGS) DESTDIR="$$dc_destdir" uninstall \
 	       && $(MAKE) $(AM_MAKEFLAGS) DESTDIR="$$dc_destdir" \
-		    distuninstallcheck_dir="$$dc_destdir" distuninstallcheck; \
+	            distuninstallcheck_dir="$$dc_destdir" distuninstallcheck; \
 	      } || { rm -rf "$$dc_destdir"; exit 1; }) \
 	  && rm -rf "$$dc_destdir" \
 	  && $(MAKE) $(AM_MAKEFLAGS) dist \
@@ -721,11 +721,11 @@ distuninstallcheck:
 	}; \
 	test `$(am__distuninstallcheck_listfiles) | wc -l` -eq 0 \
 	   || { echo "ERROR: files left after uninstall:" ; \
-		if test -n "$(DESTDIR)"; then \
-		  echo "  (check DESTDIR support)"; \
-		fi ; \
-		$(distuninstallcheck_listfiles) ; \
-		exit 1; } >&2
+	        if test -n "$(DESTDIR)"; then \
+	          echo "  (check DESTDIR support)"; \
+	        fi ; \
+	        $(distuninstallcheck_listfiles) ; \
+	        exit 1; } >&2
 distcleancheck: distclean
 	@if test '$(srcdir)' = . ; then \
 	  echo "ERROR: distcleancheck can only run from a VPATH build" ; \
@@ -862,6 +862,9 @@ uninstall-am:
 .PRECIOUS: Makefile
 
 
+# Default distribution identifier for packaging
+DISTRO ?= bookworm
+
 # Installation of configuration and SQLite database
 install-data-local:
 	$(INSTALL) -d -m 755 $(DESTDIR)/etc/scastd
@@ -881,14 +884,14 @@ permissions_great_again:
 	chmod 640 $(DESTDIR)/etc/scastd/scastd.conf $(DESTDIR)/etc/scastd/scastd.db
 	chmod 750 $(DESTDIR)/var/log/scastd
 
-# Tell versions [3.59,3.63) of GNU make to not export all variables.
-# Otherwise a system limit (for SysV at least) may be exceeded.
-.NOEXPORT:
-
 # Build platform-specific packages
 release:
 	@case "`uname -s`" in \
 	  Darwin) ./packaging/macos/build_pkg.sh $(VERSION) ;; \
-	  Linux) ./packaging/debian/build_deb.sh $(VERSION) ;; \
+	  Linux) ./packaging/debian/build_deb.sh $(VERSION) $(DISTRO) ;; \
 	  *) echo "Unsupported platform: `uname -s`" && exit 1 ;; \
 	esac
+
+# Tell versions [3.59,3.63) of GNU make to not export all variables.
+# Otherwise a system limit (for SysV at least) may be exceeded.
+.NOEXPORT:

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -3,13 +3,13 @@
 ## Release target
 
 The top-level `Makefile` provides a convenience target that builds a
-platform-appropriate package. Specify the version on the command line:
+platform-appropriate package. Specify the version and target distribution on the command line:
 
 ```bash
-make release VERSION=1.0
+make release VERSION=1.0 DISTRO=bookworm
 ```
 
-On Linux this runs `packaging/debian/build_deb.sh` and produces a `.deb`.
+On Linux this runs `packaging/debian/build_deb.sh` and produces a `.deb` in `dist/`.
 On macOS it executes `packaging/macos/build_pkg.sh` to generate a `.pkg`.
 
 ## Debian/Ubuntu
@@ -17,10 +17,10 @@ On macOS it executes `packaging/macos/build_pkg.sh` to generate a `.pkg`.
 The `packaging/debian` directory provides a helper script and systemd unit file.
 
 ```bash
-./packaging/debian/build_deb.sh 1.0
+./packaging/debian/build_deb.sh 1.0 bookworm
 ```
 
-The script compiles the project, stages the install tree and produces a `.deb` such as `scastd_1.0_amd64.deb`.
+The script compiles the project, stages the install tree and produces a `.deb` such as `scastd_1.0_bookworm_amd64.deb` inside `dist/`.
 Install the included `scastd.service` to `/etc/systemd/system` and enable it with:
 
 ```bash

--- a/packaging/debian/build_deb.sh
+++ b/packaging/debian/build_deb.sh
@@ -2,11 +2,13 @@
 set -euo pipefail
 
 VERSION=${1:-1.0}
+DISTRO=${2:-bookworm}
 PREFIX=/usr/local
 BUILD_DIR=$(pwd)/deb_build
+OUT_DIR=$(pwd)/dist
 
 rm -rf "$BUILD_DIR"
-mkdir -p "$BUILD_DIR"
+mkdir -p "$BUILD_DIR" "$OUT_DIR"
 
 # Build and stage files
 ./autogen.sh
@@ -30,4 +32,4 @@ CTRL
 cp packaging/debian/postinst "$BUILD_DIR/DEBIAN/postinst"
 chmod 755 "$BUILD_DIR/DEBIAN/postinst"
 
-dpkg-deb --build "$BUILD_DIR" "scastd_${VERSION}_$(dpkg --print-architecture).deb"
+dpkg-deb --build "$BUILD_DIR" "$OUT_DIR/scastd_${VERSION}_${DISTRO}_$(dpkg --print-architecture).deb"


### PR DESCRIPTION
## Summary
- allow specifying a Debian/Ubuntu distro when building `.deb`
- pass distro through `make release` for packaging
- document `DISTRO` usage and emit packages to `dist/`

## Testing
- `make release VERSION=1.0 DISTRO=bookworm`
- `make release VERSION=1.0 DISTRO=trixie`
- `make release VERSION=1.0 DISTRO=noble`


------
https://chatgpt.com/codex/tasks/task_e_689e633384d4832bb73c3eee7f1cde6d