### PR TITLE
chore: allow dev workflow to create releases

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,6 +7,9 @@ name: DevelopmentBuildPipeline
   pull_request:
     branches: ["dev"]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     name: Build and test (${{ matrix.distro }})


### PR DESCRIPTION
## Summary
- grant `dev` workflow permission to write repository contents

## Testing
- `yamllint .github/workflows/dev.yml`
- `./bin/act -n -W .github/workflows/dev.yml release` *(fails: no docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a01ed585fc832b9c651b1b8ec5615d