### PR TITLE
chore: allow release workflow to write contents

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -7,6 +7,9 @@ name: ProductionBuildDeployment
   pull_request:
     branches: ["master"]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     name: Build and test (${{ matrix.distro }})


### PR DESCRIPTION
## Summary
- permit production workflow to create releases

## Testing
- `./actionlint .github/workflows/prod.yaml`
- `make check` *(fails: interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_68a0204cc820832bb0632627bddda6e4