### PR TITLE
chore: set release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- ensure release workflow can publish assets by writing to repository contents

## Testing
- `yamllint .github/workflows/release.yml`
- `./bin/act -v` *(fails: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a0218818d4832b85e874bde22772b4