### PR TITLE
chore: add release notes automation

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -64,6 +64,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Build packages
         run: |
           chmod +x ${{ matrix.build_script }}
@@ -73,6 +75,21 @@ jobs:
           for file in dist/*; do
             ${{ matrix.checksum }} "$file" > "$file.sha256"
           done
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          echo "## Changes" > release_notes.md
+          git log -n 30 --pretty=format:"* %h %s (%an)" >> release_notes.md
+          COMMITS=$(git log -n 30 --pretty=format:%h | wc -l)
+          AUTHORS=$(git log -n 30 --format='%an' | sort -u | wc -l)
+          echo -e "\n## Stats\n* Commits: $COMMITS\n* Authors: $AUTHORS" >> release_notes.md
+          git log -n 30 --format='%an' | sort | uniq -c | sed 's/^/  /' >> release_notes.md
+          echo -e "\n## Links" >> release_notes.md
+          echo "- [README](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/README.md)" >> release_notes.md
+          echo "- [INSTALL](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/INSTALL.md)" >> release_notes.md
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          cat release_notes.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         env:
@@ -83,3 +100,4 @@ jobs:
           draft: false
           prerelease: true
           files: dist/*
+          body: ${{ steps.release_notes.outputs.body }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 ---
 name: Release
 
-on:
+"on":
   push:
     tags:
       - 'v*'
@@ -198,6 +198,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -207,16 +209,16 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir -p release-assets
-          
+
           # Collect all package files and checksums
           find artifacts -name "*.deb" -exec cp {} release-assets/ \;
           find artifacts -name "*.pkg" -exec cp {} release-assets/ \;
           find artifacts -name "*.rb" -exec cp {} release-assets/ \;
-          
+
           # Combine all checksum files
           echo "# SCASTD ${{ needs.prepare.outputs.version }} Release Checksums" > release-assets/CHECKSUMS.txt
           echo "" >> release-assets/CHECKSUMS.txt
-          
+
           for checksum_file in artifacts/*/checksums.txt; do
             if [[ -f "$checksum_file" ]]; then
               echo "## $(basename $(dirname "$checksum_file"))" >> release-assets/CHECKSUMS.txt
@@ -224,7 +226,7 @@ jobs:
               echo "" >> release-assets/CHECKSUMS.txt
             fi
           done
-          
+
           # List all release assets
           echo "Release assets prepared:"
           ls -la release-assets/
@@ -292,6 +294,21 @@ jobs:
 
           For detailed configuration instructions, see the [documentation](https://github.com/${{ github.repository }}/blob/master/docs/Packaging.md).
           EOF
+
+          echo "" >> release_notes.md
+          echo "## Changes" >> release_notes.md
+          git log -n 30 --pretty=format:"* %h %s (%an)" >> release_notes.md
+          COMMITS=$(git log -n 30 --pretty=format:%h | wc -l)
+          AUTHORS=$(git log -n 30 --format='%an' | sort -u | wc -l)
+          echo "" >> release_notes.md
+          echo "## Stats" >> release_notes.md
+          echo "* Commits: $COMMITS" >> release_notes.md
+          echo "* Authors: $AUTHORS" >> release_notes.md
+          git log -n 30 --format='%an' | sort | uniq -c | sed 's/^/  /' >> release_notes.md
+          echo "" >> release_notes.md
+          echo "## Links" >> release_notes.md
+          echo "- [README](https://github.com/${{ github.repository }}/blob/${{ needs.prepare.outputs.tag }}/README.md)" >> release_notes.md
+          echo "- [INSTALL](https://github.com/${{ github.repository }}/blob/${{ needs.prepare.outputs.tag }}/INSTALL.md)" >> release_notes.md
 
           # Set output for use in release creation
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- generate commit log and stats for development releases
- attach commit history and contributor stats when publishing tagged releases

## Testing
- `python -m yamllint .github/workflows/dev.yml .github/workflows/release.yml`
- `python -m yamllint -d '{extends: default, rules: {line-length: disable}}' .github/workflows/dev.yml .github/workflows/release.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a0a67b3fcc832b80a286dd12ce2ec2