### PR TITLE
ci: verify release assets via API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,6 +328,31 @@ jobs:
             release-assets/*
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # List release assets via the GitHub API and fail if any expected file is missing
+      - name: Verify uploaded release assets
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Listing assets for release $TAG"
+          assets=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+                       -H "Accept: application/vnd.github+json" \
+                       https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$TAG | jq -r '.assets[].name')
+          echo "$assets"
+          expected="scastd_${VERSION}_bookworm_amd64.deb scastd_${VERSION}_trixie_amd64.deb scastd_${VERSION}_noble_amd64.deb scastd-${VERSION}.pkg scastd.rb CHECKSUMS.txt"
+          missing=0
+          for f in $expected; do
+            if ! grep -qx "$f" <<< "$assets"; then
+              echo "::error::Missing expected release asset: $f"
+              missing=1
+            fi
+          done
+          if [ $missing -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Release Summary
         run: |
           echo "🎉 Release ${{ needs.prepare.outputs.tag }} created successfully!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,4 +33,11 @@ Thank you for your interest in improving scastd. These guidelines help keep cont
 4. Respond to feedback and update your branch as needed.
 5. A maintainer will merge the PR once it has approval and passes all checks.
 
+## Release Verification
+
+The release workflow uploads package artifacts to a GitHub Release and then
+uses the GitHub API to list the published assets. If any expected package or
+checksum file is missing, the job fails. For the exact commands, see the
+"Verify uploaded release assets" step in `.github/workflows/release.yml`.
+
 Thanks for contributing!


### PR DESCRIPTION
## Summary
- list release assets via GitHub API after uploading and fail if files missing
- document release asset verification procedure

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68a0bddd4fa4832bb0b5f03c944840ec