### PR TITLE
docs: add checksum verification instructions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -72,9 +72,9 @@ jobs:
           ${{ matrix.build_script }} ${{ github.run_number }}
       - name: Generate checksums
         run: |
-          for file in dist/*; do
-            ${{ matrix.checksum }} "$file" > "$file.sha256"
-          done
+          cd dist
+          ${{ matrix.checksum }} * > CHECKSUMS.txt
+          cat CHECKSUMS.txt
       - name: Generate release notes
         id: release_notes
         run: |
@@ -84,7 +84,11 @@ jobs:
           AUTHORS=$(git log -n 30 --format='%an' | sort -u | wc -l)
           echo -e "\n## Stats\n* Commits: $COMMITS\n* Authors: $AUTHORS" >> release_notes.md
           git log -n 30 --format='%an' | sort | uniq -c | sed 's/^/  /' >> release_notes.md
-          echo -e "\n## Links" >> release_notes.md
+          echo -e "\n## Security" >> release_notes.md
+          echo "All artifacts include SHA256 checksums in \`CHECKSUMS.txt\`. Verify downloads with:" >> release_notes.md
+          echo >> release_notes.md
+          echo -e '\n```bash\nsha256sum -c CHECKSUMS.txt\n```\n' >> release_notes.md
+          echo -e "## Links" >> release_notes.md
           echo "- [README](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/README.md)" >> release_notes.md
           echo "- [INSTALL](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/INSTALL.md)" >> release_notes.md
           echo "body<<EOF" >> $GITHUB_OUTPUT

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,12 +3,12 @@ Pre-built packages
 
 Debian/Ubuntu (.deb)
 --------------------
-Download the latest release package and its checksum. Verify and install:
+Download the latest release package and checksum file. Verify and install:
 
 ```bash
 curl -LO https://example.com/scastd_<version>_amd64.deb
-curl -LO https://example.com/scastd_<version>_amd64.deb.sha256
-sha256sum -c scastd_<version>_amd64.deb.sha256
+curl -LO https://example.com/CHECKSUMS.txt
+sha256sum -c CHECKSUMS.txt
 sudo apt install ./scastd_<version>_amd64.deb
 ```
 
@@ -22,7 +22,8 @@ macOS
 ~~~~~~~~~~~~~~
 ```bash
 curl -LO https://example.com/scastd-<version>.pkg
-shasum -a 256 scastd-<version>.pkg
+curl -LO https://example.com/CHECKSUMS.txt
+shasum -a 256 -c CHECKSUMS.txt
 sudo installer -pkg scastd-<version>.pkg -target /
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@
 
 </div>
 
+## 🔐 Verify Downloads
+
+Release artifacts include SHA256 checksums in `CHECKSUMS.txt`. Verify package integrity before installation:
+
+```bash
+sha256sum -c CHECKSUMS.txt
+```
+
+macOS users can run:
+
+```bash
+shasum -a 256 -c CHECKSUMS.txt
+```
+
 ---
 
 ## 🎯 What is SCASTD?


### PR DESCRIPTION
## Summary
- generate `CHECKSUMS.txt` during dev package builds and mention it in release notes
- document verifying downloaded artifacts using `CHECKSUMS.txt`

## Testing
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_68a0c7447610832b8fb265ca41a53c38