### PR TITLE
docs: document service verification and troubleshooting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,15 +107,25 @@ Usage: scastd [options]
 See [README.md](README.md#explore-command-line-options) for examples and
 additional parameter descriptions.
 
-HTTP endpoint smoke tests
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
+Start and verify the service
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Start scastd and confirm it responds:
 ```bash
+sudo systemctl start scastd    # or brew services start scastd
 curl http://localhost:8000/v1/status.json
 curl http://localhost:8000/v1/status.xml
-curl http://localhost:8000/v1/uptime
-curl -k https://localhost:8000/v1/status.json
 ```
+Expected output:
+```json
+{"status":"ok"}
+```
+```xml
+<status>ok</status>
+```
+Troubleshooting if unreachable:
+- Check daemon state: `sudo systemctl status scastd` or `brew services list`
+- Ensure the configured port matches `curl` URLs
+- Review firewall rules and logs in `/var/log/scastd` or via `journalctl -u scastd`
 
 TLS certificates
 ~~~~~~~~~~~~~~~~

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ For details on creating the macOS package or Homebrew formula yourself, see
 
 Update absolute paths for databases and certificates as needed.
 
-#### Enable and start the service
+#### Start and verify the service
 - **Debian/Ubuntu**
 ```bash
 sudo systemctl enable scastd
@@ -305,6 +305,24 @@ brew services start scastd
 ```bash
 sudo launchctl load -w /Library/LaunchDaemons/com.scastd.plist
 ```
+
+Confirm the daemon responds:
+```bash
+curl http://localhost:8000/v1/status.json
+curl http://localhost:8000/v1/status.xml
+```
+Expected responses:
+```json
+{"status":"ok"}
+```
+```xml
+<status>ok</status>
+```
+Troubleshooting tips if unreachable:
+- Check service state: `sudo systemctl status scastd` or `brew services list`
+- Ensure the configured port matches the `curl` command
+- Verify no firewall or other service blocks the port
+- Review logs in `/var/log/scastd` or with `journalctl -u scastd`
 
 #### Explore command-line options
 ```bash


### PR DESCRIPTION
## Summary
- Add instructions to start scastd and verify the status endpoint with curl
- Show expected JSON and XML responses and provide troubleshooting tips if unreachable

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a0cafbb5b0832b9792e83538f18d47