### PR TITLE
docs: document certificate locations and TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,13 @@ ssl_enable     true
 ssl_cert       /etc/letsencrypt/live/example.com/fullchain.pem
 ssl_key        /etc/letsencrypt/live/example.com/privkey.pem
 ```
+On macOS the Homebrew prefix contains the certificates:
+```conf
+ssl_enable     true
+ssl_cert       /usr/local/etc/letsencrypt/live/example.com/fullchain.pem
+ssl_key        /usr/local/etc/letsencrypt/live/example.com/privkey.pem
+# Use /opt/homebrew on Apple Silicon
+```
 
 #### Test HTTP/HTTPS endpoints
 ```bash
@@ -373,6 +380,7 @@ curl http://localhost:8000/v1/status.json
 curl http://localhost:8000/v1/status.xml
 curl http://localhost:8000/v1/uptime
 curl -k https://localhost:8000/v1/status.json
+curl https://example.com:8000/v1/status.json
 ```
 
 #### Obtain TLS certificates
@@ -385,13 +393,22 @@ sudo certbot certonly --standalone -d example.com
 brew install certbot
 sudo certbot certonly --standalone -d example.com
 ```
-Certificates are typically stored at:
+Certificates are placed under the Let's Encrypt directory for your
+platform:
+
+| Platform | Certificate path |
+| --- | --- |
+| Debian/Ubuntu | `/etc/letsencrypt/live/example.com/` |
+| macOS (Intel) | `/usr/local/etc/letsencrypt/live/example.com/` |
+| macOS (Apple Silicon) | `/opt/homebrew/etc/letsencrypt/live/example.com/` |
+
+Reference `fullchain.pem` and `privkey.pem` from that directory in
+`scastd.conf` and restart the daemon:
+
+```bash
+sudo systemctl restart scastd      # or reload
+brew services restart scastd       # macOS
 ```
-/etc/letsencrypt/live/example.com/fullchain.pem
-/etc/letsencrypt/live/example.com/privkey.pem
-```
-Restart the service after changes:
-`sudo systemctl restart scastd` or `brew services restart scastd`.
 
 ---
 

--- a/docs/HTTPS.md
+++ b/docs/HTTPS.md
@@ -20,3 +20,58 @@ On Debian or Ubuntu systems, `apt` installs Certbot and a `systemd` timer is
 enabled via `systemctl enable --now certbot.timer`.
 
 Certificates and keys are stored under `/etc/letsencrypt/`.
+
+## Certificate locations
+
+Certbot writes certificates to different directories depending on the
+operating system:
+
+| Platform | Default path |
+| --- | --- |
+| Debian/Ubuntu | `/etc/letsencrypt/live/<domain>/` |
+| macOS (Intel) | `/usr/local/etc/letsencrypt/live/<domain>/` |
+| macOS (Apple Silicon) | `/opt/homebrew/etc/letsencrypt/live/<domain>/` |
+
+Each directory contains `fullchain.pem` (certificate) and
+`privkey.pem` (private key).
+
+## Configure `scastd`
+
+Reference these files in `scastd.conf` to enable HTTPS:
+
+### Debian/Ubuntu
+
+```conf
+ssl_enable     true
+ssl_cert       /etc/letsencrypt/live/example.com/fullchain.pem
+ssl_key        /etc/letsencrypt/live/example.com/privkey.pem
+```
+
+### macOS (Intel)
+
+```conf
+ssl_enable     true
+ssl_cert       /usr/local/etc/letsencrypt/live/example.com/fullchain.pem
+ssl_key        /usr/local/etc/letsencrypt/live/example.com/privkey.pem
+```
+
+On Apple Silicon replace `/usr/local` with `/opt/homebrew`.
+
+## Restart the daemon
+
+Reload or restart SCASTD after installing or renewing certificates:
+
+```bash
+sudo systemctl restart scastd      # Debian/Ubuntu
+brew services restart scastd       # macOS
+```
+
+## Verify TLS
+
+Confirm the server responds over HTTPS:
+
+```bash
+curl https://example.com:8000/v1/status.json
+```
+
+The command should return the service status without TLS errors.


### PR DESCRIPTION
## Summary
- explain default Let's Encrypt certificate directories for Debian/Ubuntu and macOS
- show matching `scastd.conf` blocks enabling HTTPS
- mention restarting the daemon and verifying TLS with `curl`

## Testing
- `./configure` *(fails: cannot find required auxiliary files)*
- `autoreconf -i` *(fails: autopoint missing)*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68a0cc546e38832b9d43f237435693bc