### PR TITLE
feat: generate release notes via script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,17 +295,8 @@ jobs:
 
           For detailed configuration instructions, see the [documentation](https://github.com/${{ github.repository }}/blob/master/docs/Packaging.md).
           EOF
-
-          echo "" >> release_notes.md
-          echo "## Changes" >> release_notes.md
-          git log -n 30 --pretty=format:"* %h %s (%an)" >> release_notes.md
-          COMMITS=$(git log -n 30 --pretty=format:%h | wc -l)
-          AUTHORS=$(git log -n 30 --format='%an' | sort -u | wc -l)
-          echo "" >> release_notes.md
-          echo "## Stats" >> release_notes.md
-          echo "* Commits: $COMMITS" >> release_notes.md
-          echo "* Authors: $AUTHORS" >> release_notes.md
-          git log -n 30 --format='%an' | sort | uniq -c | sed 's/^/  /' >> release_notes.md
+          PREV_TAG=$(git tag --sort=committerdate | tail -n 2 | head -n 1)
+          ./scripts/generate_release_notes.sh "$PREV_TAG" "${{ needs.prepare.outputs.tag }}" >> release_notes.md
           echo "" >> release_notes.md
           echo "## Links" >> release_notes.md
           echo "- [README](https://github.com/${{ github.repository }}/blob/${{ needs.prepare.outputs.tag }}/README.md)" >> release_notes.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,19 @@ uses the GitHub API to list the published assets. If any expected package or
 checksum file is missing, the job fails. For the exact commands, see the
 "Verify uploaded release assets" step in `.github/workflows/release.yml`.
 
+## Release Notes
+
+Release notes are generated with `scripts/generate_release_notes.sh`. The
+script summarizes commits, contributors, and line counts between two refs and
+outputs Markdown suitable for GitHub releases.
+
+To preview the notes locally for the range between two tags:
+
+```bash
+scripts/generate_release_notes.sh v79 v81
+```
+
+If no starting ref is provided, the script compares the previous tag to the
+current `HEAD`.
+
 Thanks for contributing!

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+START_REF=${1:-}
+END_REF=${2:-HEAD}
+
+if [ -z "$START_REF" ]; then
+  START_REF=$(git describe --tags --abbrev=0 "$END_REF^" 2>/dev/null || git rev-list --max-parents=0 HEAD)
+fi
+
+RANGE="$START_REF..$END_REF"
+
+echo "## Changes"
+git log --no-merges --pretty=format:"* %h %s (%an)" "$RANGE"
+echo
+
+CONTRIBUTORS=$(git log --format='%an' "$RANGE" | sort -u)
+COUNT=$(echo "$CONTRIBUTORS" | wc -l | tr -d ' ')
+
+echo "## Contributors"
+echo "Total contributors: $COUNT"
+echo "$CONTRIBUTORS" | sed 's/^/- /'
+echo
+
+STATS=$(git diff --shortstat "$RANGE")
+FILES=$(echo "$STATS" | grep -o '[0-9]\+ file' | grep -o '[0-9]\+' || echo 0)
+ADDED=$(echo "$STATS" | grep -o '\([0-9]\+\) insertions' | grep -o '[0-9]\+' || echo 0)
+REMOVED=$(echo "$STATS" | grep -o '\([0-9]\+\) deletions' | grep -o '[0-9]\+' || echo 0)
+
+echo "## Stats"
+echo "- Files changed: $FILES"
+echo "- Lines added: $ADDED"
+echo "- Lines removed: $REMOVED"


### PR DESCRIPTION
## Summary
- add reusable `generate_release_notes.sh` script to collect commits, contributors, and diff stats
- integrate the script into the release workflow
- document how to use the release notes script

## Testing
- `scripts/generate_release_notes.sh v79 v81`
- `make check` *(fails: No rule to make target 'check')*
- `./configure` *(fails: cannot find required auxiliary files)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d16d0adc832b9cef2a4830883ada