### PR TITLE
docs: mention macOS pkg and Homebrew formula in install docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,6 @@
 Pre-built packages
 ==================
+Releases provide Debian `.deb` packages, a macOS `.pkg` installer, and a Homebrew formula (`scastd.rb`).
 
 Debian/Ubuntu (.deb)
 --------------------
@@ -33,9 +34,18 @@ daemon with `sudo launchctl load -w /Library/LaunchDaemons/com.scastd.plist`.
 
 Homebrew formula
 ~~~~~~~~~~~~~~~~
+Release archives also ship `scastd.rb`. To verify the formula locally:
+
 ```bash
-brew install scastd
+brew install --formula ./scastd.rb
 brew services start scastd
+```
+
+Update or remove the formula:
+
+```bash
+brew upgrade scastd
+brew uninstall scastd
 ```
 
 For information on building the macOS package or generating a Homebrew

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 
 ## 🔐 Verify Downloads
 
-Release artifacts include SHA256 checksums in `CHECKSUMS.txt`. Verify package integrity before installation:
+Releases ship Debian `.deb` packages, a macOS `.pkg` installer, and a Homebrew formula (`scastd.rb`). SHA256 checksums for all artifacts are provided in `CHECKSUMS.txt`. Verify package integrity before installation:
 
 ```bash
 sha256sum -c CHECKSUMS.txt
@@ -274,9 +274,30 @@ sudo installer -pkg scastd-<version>.pkg -target /
 ```
 
 #### macOS (Homebrew)
+Release archives include a `scastd.rb` Homebrew formula. To test it locally:
+
+```bash
+brew install --formula ./scastd.rb
+brew services start scastd
+```
+
+Once verified, install from the official tap:
+
 ```bash
 brew tap davestj/scastd
 brew install scastd
+```
+
+To update the formula later:
+
+```bash
+brew upgrade scastd
+```
+
+To remove it:
+
+```bash
+brew uninstall scastd
 ```
 
 For details on creating the macOS package or Homebrew formula yourself, see


### PR DESCRIPTION
## Summary
- note that releases provide `.pkg` installers and a Homebrew `scastd.rb` formula
- show how to test the Homebrew formula locally, start the service, and update or remove it

## Testing
- `./autogen.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a0d27ce264832b9a9c94a6ee17970f