### PR TITLE
Add post-release package verification job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,3 +352,58 @@ jobs:
           ls -la release-assets/
           echo ""
           echo "🔗 Release URL: https://github.com/${{ github.repository }}/releases/tag/${{ needs.prepare.outputs.tag }}"
+
+  verify-install:
+    needs: [prepare, build-packages]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            container: debian:12
+            package: scastd_${{ needs.prepare.outputs.version }}_bookworm_amd64.deb
+          - os: ubuntu-22.04
+            container: debian:trixie
+            package: scastd_${{ needs.prepare.outputs.version }}_trixie_amd64.deb
+          - os: ubuntu-24.04
+            container: ubuntu:24.04
+            package: scastd_${{ needs.prepare.outputs.version }}_noble_amd64.deb
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    steps:
+      - name: Download release package
+        run: |
+          curl -L -o ${{ matrix.package }} https://github.com/${{ github.repository }}/releases/download/${{ needs.prepare.outputs.tag }}/${{ matrix.package }}
+
+      - name: Install package
+        run: |
+          apt-get update
+          apt-get install -y curl
+          dpkg -i ${{ matrix.package }} || (apt-get -f install -y && dpkg -i ${{ matrix.package }})
+
+      - name: Verify scastd version
+        run: |
+          out=$(scastd --version)
+          echo "$out"
+          grep "${{ needs.prepare.outputs.version }}" <<< "$out"
+
+      - name: HTTP test
+        run: |
+          cat > scastd.conf <<'EOF'
+          pid_file /tmp/scastd.pid
+          log_dir /tmp
+          access_log access.log
+          error_log error.log
+          debug_log debug.log
+          debug_level 1
+          log_console true
+          http_enabled true
+          http_port 8000
+          DatabaseType sqlite
+          sqlite_path /tmp/scastd.db
+          EOF
+          scastd --config scastd.conf &
+          PID=$!
+          sleep 2
+          curl -f http://localhost:8000/status.json
+          kill $PID


### PR DESCRIPTION
## Summary
- verify released Debian/Ubuntu packages by installing them and running `scastd --version`
- perform a basic HTTP `/status.json` request to ensure the daemon responds

## Testing
- `apt-get update`
- `apt-get install -y build-essential autoconf automake libtool pkg-config gettext autopoint libxml2-dev libcurl4-openssl-dev libmysqlclient-dev libpq-dev libmicrohttpd-dev libsqlite3-dev`
- `./autogen.sh`
- `./configure`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68a0d9d13db4832b9f5d4b38b8d0f652