### PR TITLE
chore: install MySQL client libs from upstream

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -17,25 +17,34 @@ runs:
         command -v sudo >/dev/null 2>&1 && SUDO="sudo"
         $SUDO apt-get update
         
-        # For Debian, skip libmysqlclient-dev and use MariaDB for base dependencies
-        if [[ "${{ inputs.distro }}" == "debian-12" || "${{ inputs.distro }}" == "debian-13" ]]; then
-          $SUDO apt-get install -y \
-            build-essential \
-            autoconf automake libtool pkg-config \
-            gettext \
-            autopoint \
-            libxml2-dev libcurl4-openssl-dev \
-            libmariadb-dev libmariadb-dev-compat mariadb-client libpq-dev libmicrohttpd-dev libsqlite3-dev wget
-        else
-          # Ubuntu can still use libmysqlclient-dev
-          $SUDO apt-get install -y \
-            build-essential \
-            autoconf automake libtool pkg-config \
-            gettext \
-            autopoint \
-            libxml2-dev libcurl4-openssl-dev \
-            libmysqlclient-dev mariadb-client libpq-dev libmicrohttpd-dev libsqlite3-dev wget
-        fi
+        $SUDO apt-get install -y \
+          build-essential \
+          autoconf automake libtool pkg-config \
+          gettext \
+          autopoint \
+          libxml2-dev libcurl4-openssl-dev \
+          mariadb-client libpq-dev libmicrohttpd-dev libsqlite3-dev wget
+
+        case "${{ inputs.distro }}" in
+          debian-12)
+            wget https://dev.mysql.com/get/Downloads/MySQL-8.0/libmysqlclient21_8.0.39-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/MySQL-8.0/libmysqlclient-dev_8.0.39-1debian12_amd64.deb
+            ;;
+          debian-13)
+            wget https://dev.mysql.com/get/Downloads/MySQL-8.0/libmysqlclient21_8.0.39-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/MySQL-8.0/libmysqlclient-dev_8.0.39-1debian12_amd64.deb
+            ;;
+          ubuntu-24.04)
+            wget https://dev.mysql.com/get/Downloads/MySQL-8.0/libmysqlclient21_8.0.39-1ubuntu24.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/MySQL-8.0/libmysqlclient-dev_8.0.39-1ubuntu24.04_amd64.deb
+            ;;
+          ubuntu-22.04)
+            wget https://dev.mysql.com/get/Downloads/MySQL-8.0/libmysqlclient21_8.0.39-1ubuntu22.04_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/MySQL-8.0/libmysqlclient-dev_8.0.39-1ubuntu22.04_amd64.deb
+            ;;
+        esac
+        $SUDO dpkg -i libmysqlclient21_8.0.39-1*.deb libmysqlclient-dev_8.0.39-1*.deb || true
+        $SUDO apt-get -f install -y
         wget https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.tar.gz
         tar -xf gettext-0.22.tar.gz
         cd gettext-0.22


### PR DESCRIPTION
## Summary
- drop MariaDB client dev packages on Debian and always install base build deps
- install libmysqlclient21 and libmysqlclient-dev directly from mysql.com for each distro

## Testing
- `./bin/act -j test -W .github/workflows/dev.yml` *(fails: daemon Docker Engine socket not found)*
- `./bin/act -j test -W .github/workflows/prod.yaml` *(fails: daemon Docker Engine socket not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ef8002e8832b9b5f55dfdde314d3