### PR TITLE
Run autogen and configure before release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,11 @@ jobs:
         with:
           version: mysql-connector-c++-9.4.0-macos15-arm64
 
+      - name: Prepare build system
+        run: |
+          ./autogen.sh
+          ./configure
+
       - name: Build release package
         run: |
           # Determine appropriate DISTRO value for make release


### PR DESCRIPTION
## Summary
- ensure the release workflow prepares the build system by running `autogen.sh` and `configure` before invoking `make release`

## Testing
- `make check` *(fails: unit_tests)*
- `gh workflow run release.yml` *(fails: authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f41ff358832b81bb8cc490f4adc2