### PR TITLE
chore: add mysql dev sanity checks

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -45,8 +45,9 @@ runs:
         esac
         $SUDO dpkg -i libmysqlclient21_8.4.0-1*.deb libmysqlclient-dev_8.4.0-1*.deb || true
         $SUDO apt-get -f install -y
-        mysql_config --version
+        dpkg -s libmysqlclient-dev | grep -q '^Status: install ok'
         test -f /usr/include/mysql/mysql.h
+        mysql_config --version
         wget https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.tar.gz
         tar -xf gettext-0.22.tar.gz
         cd gettext-0.22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,18 +78,24 @@ jobs:
               wget https://dev.mysql.com/get/Downloads/MySQL-8.4/libmysqlclient-dev_8.4.0-1debian12_amd64.deb
               $SUDO dpkg -i libmysqlclient21_8.4.0-1debian12_amd64.deb libmysqlclient-dev_8.4.0-1debian12_amd64.deb || true
               $SUDO apt-get -f install -y
+              dpkg -s libmysqlclient-dev | grep -q '^Status: install ok'
+              test -f /usr/include/mysql/mysql.h
               ;;
             debian-trixie)
               wget https://dev.mysql.com/get/Downloads/MySQL-8.4/libmysqlclient21_8.4.0-1debian12_amd64.deb
               wget https://dev.mysql.com/get/Downloads/MySQL-8.4/libmysqlclient-dev_8.4.0-1debian12_amd64.deb
               $SUDO dpkg -i libmysqlclient21_8.4.0-1debian12_amd64.deb libmysqlclient-dev_8.4.0-1debian12_amd64.deb || true
               $SUDO apt-get -f install -y
+              dpkg -s libmysqlclient-dev | grep -q '^Status: install ok'
+              test -f /usr/include/mysql/mysql.h
               ;;
             ubuntu-24.04)
               wget https://dev.mysql.com/get/Downloads/MySQL-8.4/libmysqlclient21_8.4.0-1ubuntu24.04_amd64.deb
               wget https://dev.mysql.com/get/Downloads/MySQL-8.4/libmysqlclient-dev_8.4.0-1ubuntu24.04_amd64.deb
               $SUDO dpkg -i libmysqlclient21_8.4.0-1ubuntu24.04_amd64.deb libmysqlclient-dev_8.4.0-1ubuntu24.04_amd64.deb || true
               $SUDO apt-get -f install -y
+              dpkg -s libmysqlclient-dev | grep -q '^Status: install ok'
+              test -f /usr/include/mysql/mysql.h
               ;;
           esac
 


### PR DESCRIPTION
## Summary
- ensure libmysqlclient-dev and headers are present before building
- verify mysql development files exist in release workflow for each distro

## Testing
- `yamllint .github/actions/build-and-test/action.yml .github/workflows/release.yml`
- `bash -euc 'dpkg -s libmysqlclient-dev | grep -q "^Status: install ok"; test -f /usr/include/mysql/mysql.h; echo ok'`
- ❌ `sudo apt-get install -y act` (package not found)


------
https://chatgpt.com/codex/tasks/task_e_68a116db78b0832b99ac1495aa623b1d