### PR TITLE
Use softprops release action

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -56,11 +56,10 @@ jobs:
     steps:
       - name: Create GitHub release
         if: success()
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ github.run_number }}
-          release_name: Release ${{ github.run_number }}
+          name: Release ${{ github.run_number }}
           draft: true
           prerelease: false


### PR DESCRIPTION
## Summary
- use `softprops/action-gh-release@v2` for releases
- pass `GITHUB_TOKEN` via `with` block

## Testing
- `yamllint .github/workflows/prod.yaml`
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68a13625b54c832b84fa6da6a22bf461