### PR TITLE
chore: configure future release workflow

### DIFF
--- a/.github/workflows/future.yml
+++ b/.github/workflows/future.yml
@@ -1,6 +1,9 @@
 ---
 name: FutureBuildPipeline
 
+permissions:
+  contents: write
+
 "on":
   push:
     branches: ["future"]
@@ -49,15 +52,14 @@ jobs:
   release:
     needs: [test, lint]
     runs-on: ubuntu-24.04
-    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/future' && github.event_name == 'push'
     steps:
       - name: Create GitHub release
         if: success()
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ github.run_number }}
-          release_name: Release ${{ github.run_number }}
+          name: Release ${{ github.run_number }}
           draft: false
           prerelease: true


### PR DESCRIPTION
## Summary
- enable contents write permissions in future CI workflow
- release only when pushing to future branch
- use softprops/action-gh-release for future releases

## Testing
- `make check` (fails: No rule to make target 'check')
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68a162ab88ac832b89fd6fecf45a1d88