### PR TITLE
ci: use GH_PAT for releases

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -96,9 +96,8 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          token: ${{ secrets.GH_PAT }}
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}
           draft: false

--- a/.github/workflows/future.yml
+++ b/.github/workflows/future.yml
@@ -58,7 +58,7 @@ jobs:
         if: success()
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}
           draft: false

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -58,7 +58,7 @@ jobs:
         if: success()
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,14 +354,14 @@ jobs:
           prerelease: false
           files: |
             release-assets/*
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       # List release assets via the GitHub API and fail if any expected file is missing
       - name: Verify uploaded release assets
         env:
           TAG: ${{ needs.prepare.outputs.tag }}
           VERSION: ${{ needs.prepare.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           echo "Listing assets for release $TAG"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,13 @@ uses the GitHub API to list the published assets. If any expected package or
 checksum file is missing, the job fails. For the exact commands, see the
 "Verify uploaded release assets" step in `.github/workflows/release.yml`.
 
+## Release Authentication
+
+The workflows that publish releases require a Personal Access Token (PAT) with
+the `repo` scope stored as `GH_PAT` in the repository secrets. The release
+jobs use this token via the `with: token:` field to upload assets and create
+GitHub releases.
+
 ## Release Notes
 
 Release notes are generated with `scripts/generate_release_notes.sh`. The


### PR DESCRIPTION
## Summary
- use `secrets.GH_PAT` for release workflow tokens
- document GH_PAT requirement in contributing guide

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a16b5547cc832b969ee62e7e6fa1ef