### PR TITLE
chore: verify release existence

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -104,3 +104,19 @@ jobs:
           prerelease: true
           files: dist/*
           body: ${{ steps.release_notes.outputs.body }}
+      - name: Verify release
+        env:
+          TAG: v${{ github.run_number }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          response=$(curl -sSf -H "Authorization: Bearer $GITHUB_TOKEN" \
+                         -H "Accept: application/vnd.github+json" \
+                         https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/$TAG)
+          url=$(echo "$response" | jq -r '.html_url')
+          assets=$(echo "$response" | jq '.assets | length')
+          if [ "$assets" -eq 0 ]; then
+            echo "::error::Release has no assets"
+            exit 1
+          fi
+          echo "Release URL: $url"

--- a/.github/workflows/future.yml
+++ b/.github/workflows/future.yml
@@ -63,3 +63,19 @@ jobs:
           name: Release ${{ github.run_number }}
           draft: false
           prerelease: true
+      - name: Verify release
+        env:
+          TAG: v${{ github.run_number }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          response=$(curl -sSf -H "Authorization: Bearer $GITHUB_TOKEN" \
+                         -H "Accept: application/vnd.github+json" \
+                         https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/$TAG)
+          url=$(echo "$response" | jq -r '.html_url')
+          assets=$(echo "$response" | jq '.assets | length')
+          if [ "$assets" -eq 0 ]; then
+            echo "::error::Release has no assets"
+            exit 1
+          fi
+          echo "Release URL: $url"

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -63,3 +63,19 @@ jobs:
           name: Release ${{ github.run_number }}
           draft: true
           prerelease: false
+      - name: Verify release
+        env:
+          TAG: v${{ github.run_number }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          response=$(curl -sSf -H "Authorization: Bearer $GITHUB_TOKEN" \
+                         -H "Accept: application/vnd.github+json" \
+                         https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/$TAG)
+          url=$(echo "$response" | jq -r '.html_url')
+          assets=$(echo "$response" | jq '.assets | length')
+          if [ "$assets" -eq 0 ]; then
+            echo "::error::Release has no assets"
+            exit 1
+          fi
+          echo "Release URL: $url"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,9 +365,16 @@ jobs:
         run: |
           set -euo pipefail
           echo "Listing assets for release $TAG"
-          assets=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
-                       -H "Accept: application/vnd.github+json" \
-                       https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$TAG | jq -r '.assets[].name')
+          response=$(curl -sSf -H "Authorization: Bearer $GITHUB_TOKEN" \
+                             -H "Accept: application/vnd.github+json" \
+                             https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$TAG)
+          url=$(echo "$response" | jq -r '.html_url')
+          assets=$(echo "$response" | jq -r '.assets[].name')
+          asset_count=$(echo "$response" | jq '.assets | length')
+          if [ "$asset_count" -eq 0 ]; then
+            echo "::error::Release has no assets"
+            exit 1
+          fi
           echo "$assets"
           expected="scastd_${VERSION}_bookworm_amd64.deb scastd_${VERSION}_trixie_amd64.deb scastd_${VERSION}_noble_amd64.deb scastd-${VERSION}.pkg scastd.rb CHECKSUMS.txt"
           missing=0
@@ -380,6 +387,7 @@ jobs:
           if [ $missing -ne 0 ]; then
             exit 1
           fi
+          echo "Release URL: $url"
 
       - name: Release Summary
         run: |


### PR DESCRIPTION
## Summary
- check GitHub release after creation across workflows and log release URL
- fail workflows if release missing or has no assets

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a16dda0fcc832b9b20b019d2677928