### PR TITLE
ci: use repo token for dev release workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}
           draft: false
@@ -107,7 +107,7 @@ jobs:
       - name: Verify release
         env:
           TAG: v${{ github.run_number }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           response=$(curl -sSf -H "Authorization: Bearer $GITHUB_TOKEN" \


### PR DESCRIPTION
## Summary
- ensure development workflow has write permissions
- use `softprops/action-gh-release@v2` with explicit `${{ secrets.GITHUB_TOKEN }}`

## Testing
- `yamllint -d "{extends: default, rules: {line-length: {max: 200}}}" .github/workflows/dev.yml`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a17782d204832b8ade24dd09117cdf