### PR TITLE
chore: update MySQL connector downloads

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -16,7 +16,7 @@ runs:
         SUDO=""
         command -v sudo >/dev/null 2>&1 && SUDO="sudo"
         $SUDO apt-get update
-        
+
         $SUDO apt-get install -y \
           build-essential \
           autoconf automake libtool pkg-config \
@@ -57,25 +57,47 @@ runs:
         cd ..
         echo "PATH=/usr/local/bin:$PATH" >> $GITHUB_ENV
         if [[ "${{ inputs.distro }}" == "debian-12" || "${{ inputs.distro }}" == "debian-13" ]]; then
-          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
           wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
           wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
           wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
-          $SUDO dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
+          $SUDO dpkg -i \
+            libmysqlcppconn10_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconnx2_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb || true
           $SUDO apt-get -f install -y
         elif [[ "${{ inputs.distro }}" == "ubuntu-24.04" ]]; then
-          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
-          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
-          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
-          $SUDO dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
+          $SUDO dpkg -i \
+            libmysqlcppconn10_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconnx2_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb || true
           $SUDO apt-get -f install -y
         else
-          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb
-          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb
-          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb
-          $SUDO dpkg -i libmysqlcppconn10_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu22.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu22.04_amd64.deb || true
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb
+          wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
+          $SUDO dpkg -i \
+            libmysqlcppconn10_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconnx2_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb \
+            libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb || true
           $SUDO apt-get -f install -y
         fi
+        test -d /usr/include/mysql-cppconn
+        mysql_config --version
         export CPPFLAGS="$(mysql_config --cflags) $CPPFLAGS"
         export LDFLAGS="$(mysql_config --libs) $LDFLAGS"
     - name: Install dependencies (macOS)
@@ -100,9 +122,18 @@ runs:
         echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
     - name: Setup MySQL Connector
       if: ${{ inputs.distro == 'macos-14' }}
-      uses: ./.github/actions/setup-mysql-connector
-      with:
-        version: mysql-connector-c++-9.4.0-macos15-arm64
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -LO https://dev.mysql.com/get/Downloads/Connector-C++/mysql-connector-c++-9.4.0-macos15-x86-64bit.dmg
+        hdiutil attach mysql-connector-c++-9.4.0-macos15-x86-64bit.dmg
+        sudo installer -pkg /Volumes/mysql-connector-c++-9.4.0-macos15-x86-64bit/mysql-connector-c++-9.4.0-macos15-x86-64bit.pkg -target /
+        hdiutil detach /Volumes/mysql-connector-c++-9.4.0-macos15-x86-64bit
+        export CPPFLAGS="-I/usr/local/include/mysql-cppconn $CPPFLAGS"
+        export LDFLAGS="-L/usr/local/lib $LDFLAGS"
+        echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
+        echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
+        echo "PATH=$PATH" >> $GITHUB_ENV
     - name: Show environment variables
       if: ${{ inputs.distro == 'macos-14' }}
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,26 +109,45 @@ jobs:
           cd ..
           echo "PATH=/usr/local/bin:$PATH" >> $GITHUB_ENV
 
-          # Install MySQL Connector C++ based on distribution
+          # Install MySQL Connector/C++
           if [[ "${{ matrix.distro }}" == "debian-12" ]]; then
-            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
-            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
+            $SUDO dpkg -i \
+              libmysqlcppconn10_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconnx2_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb || true
             $SUDO apt-get -f install -y
           elif [[ "${{ matrix.distro }}" == "debian-trixie" ]]; then
-            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
             wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
-            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1debian12_amd64.deb libmysqlcppconnx2_9.4.0-1debian12_amd64.deb libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb || true
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
+            $SUDO dpkg -i \
+              libmysqlcppconn10_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconnx2_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb || true
             $SUDO apt-get -f install -y
           elif [[ "${{ matrix.distro }}" == "ubuntu-24.04" ]]; then
-            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb
-            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb
-            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb
-            $SUDO dpkg -i libmysqlcppconn10_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconnx2_9.4.0-1ubuntu24.04_amd64.deb libmysqlcppconn-dev_9.4.0-1ubuntu24.04_amd64.deb || true
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb
+            wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb
+            $SUDO dpkg -i \
+              libmysqlcppconn10_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconnx2_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconn-dev_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb \
+              libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb || true
             $SUDO apt-get -f install -y
           fi
 
@@ -139,6 +158,10 @@ jobs:
           fi
           if [[ ! -f /usr/include/mysql/mysql.h ]]; then
             echo "/usr/include/mysql/mysql.h not found" >&2
+            exit 1
+          fi
+          if [[ ! -d /usr/include/mysql-cppconn ]]; then
+            echo "/usr/include/mysql-cppconn not found" >&2
             exit 1
           fi
           mysql_config --version
@@ -171,9 +194,17 @@ jobs:
 
       - name: Setup MySQL Connector (macOS)
         if: ${{ matrix.distro == 'macos-arm64' }}
-        uses: ./.github/actions/setup-mysql-connector
-        with:
-          version: mysql-connector-c++-9.4.0-macos15-arm64
+        run: |
+          set -euo pipefail
+          curl -LO https://dev.mysql.com/get/Downloads/Connector-C++/mysql-connector-c++-9.4.0-macos15-x86-64bit.dmg
+          hdiutil attach mysql-connector-c++-9.4.0-macos15-x86-64bit.dmg
+          sudo installer -pkg /Volumes/mysql-connector-c++-9.4.0-macos15-x86-64bit/mysql-connector-c++-9.4.0-macos15-x86-64bit.pkg -target /
+          hdiutil detach /Volumes/mysql-connector-c++-9.4.0-macos15-x86-64bit
+          export CPPFLAGS="-I/usr/local/include/mysql-cppconn $CPPFLAGS"
+          export LDFLAGS="-L/usr/local/lib $LDFLAGS"
+          echo "CPPFLAGS=$CPPFLAGS" >> $GITHUB_ENV
+          echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
+          echo "PATH=$PATH" >> $GITHUB_ENV
 
       - name: Prepare build system
         run: |


### PR DESCRIPTION
## Summary
- use consistent MySQL Connector/C++ Debian 12 packages with debug symbols across build and release workflows
- install macOS connector via x86-64 DMG and expose headers and libs
- verify connector install by checking `/usr/include/mysql-cppconn` and running `mysql_config --version`

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 400}}}' .github/actions/build-and-test/action.yml .github/workflows/release.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a1796d2184832b942e62a2c5488827