### PR TITLE
ci: use GH_PAT for release workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           tag_name: v${{ github.run_number }}
           name: Release ${{ github.run_number }}
           draft: false
@@ -107,7 +107,7 @@ jobs:
       - name: Verify release
         env:
           TAG: v${{ github.run_number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           response=$(curl -sSf -H "Authorization: Bearer $GITHUB_TOKEN" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,10 @@ checksum file is missing, the job fails. For the exact commands, see the
 
 ## Release Authentication
 
-The workflows that publish releases require a Personal Access Token (PAT) with
-the `repo` scope stored as `GH_PAT` in the repository secrets. The release
-jobs use this token via the `with: token:` field to upload assets and create
-GitHub releases.
+The release workflows require a GitHub Personal Access Token (PAT) with the
+`repo` scope. Generate a PAT from your GitHub "Developer settings" page and
+add it to the repository secrets as `GH_PAT`. The jobs reference this token via
+`token: ${{ secrets.GH_PAT }}` to upload assets and create GitHub releases.
 
 ## Release Notes
 


### PR DESCRIPTION
## Summary
- use `GH_PAT` secret for release uploads in dev workflow
- document required `GH_PAT` token in contributing guide

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68a1f9011104832bbead910ac86d989a