### PR TITLE
Verify MySQL connector installation in workflows

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -69,6 +69,8 @@ runs:
             libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb \
             libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb || true
           $SUDO apt-get -f install -y
+          dpkg -s libmysqlcppconn-dev | grep -q '^Status: install ok'
+          test -f /usr/include/mysql-cppconn/jdbc/mysql_driver.h
         elif [[ "${{ inputs.distro }}" == "ubuntu-24.04" ]]; then
           wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
           wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
@@ -82,6 +84,8 @@ runs:
             libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb \
             libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb || true
           $SUDO apt-get -f install -y
+          dpkg -s libmysqlcppconn-dev | grep -q '^Status: install ok'
+          test -f /usr/include/mysql-cppconn/jdbc/mysql_driver.h
         else
           wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconn10_9.4.0-1debian12_amd64.deb
           wget https://dev.mysql.com/get/Downloads/Connector-C++/libmysqlcppconnx2_9.4.0-1debian12_amd64.deb
@@ -95,6 +99,8 @@ runs:
             libmysqlcppconn10-dbgsym_9.4.0-1debian12_amd64.deb \
             libmysqlcppconnx2-dbgsym_9.4.0-1debian12_amd64.deb || true
           $SUDO apt-get -f install -y
+          dpkg -s libmysqlcppconn-dev | grep -q '^Status: install ok'
+          test -f /usr/include/mysql-cppconn/jdbc/mysql_driver.h
         fi
         test -d /usr/include/mysql-cppconn
         mysql_config --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
             $SUDO apt-get -f install -y
           fi
 
+          dpkg -s libmysqlcppconn-dev | grep -q '^Status: install ok'
+          test -f /usr/include/mysql-cppconn/jdbc/mysql_driver.h
+
           # Verify MySQL headers and configure build flags
           if ! command -v mysql_config >/dev/null; then
             echo "mysql_config not found" >&2


### PR DESCRIPTION
## Summary
- ensure MySQL C++ connector packages install correctly in the reusable build-and-test action
- verify connector presence in release workflow before building packages

## Testing
- `./autogen.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a22fa3c8f0832b858e4efd308721fb