### PR TITLE
chore: update unknown DB type fallback

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -185,3 +185,16 @@ msgstr "Sleeping for %d seconds\n"
 #, c-format
 #~ msgid "Bad data from %s\n"
 #~ msgstr "Bad data from %s\n"
+
+#: src/scastd.cpp
+#, c-format
+msgid ""
+"Unknown DatabaseType '%s'. Supported values are mariadb, postgres. "
+"Falling back to default 'mariadb'.\\n"
+msgstr ""
+"Unknown DatabaseType '%s'. Supported values are mariadb, postgres. "
+"Falling back to default 'mariadb'.\\n"
+
+#: src/scastd.cpp
+msgid "Unknown DatabaseType. Falling back to mariadb\\n"
+msgstr "Unknown DatabaseType. Falling back to mariadb\\n"

--- a/po/scastd.pot
+++ b/po/scastd.pot
@@ -150,3 +150,14 @@ msgstr ""
 #, c-format
 msgid "Sleeping for %d ms\n"
 msgstr ""
+
+#: src/scastd.cpp
+#, c-format
+msgid ""
+"Unknown DatabaseType '%s'. Supported values are mariadb, postgres. "
+"Falling back to default 'mariadb'.\\n"
+msgstr ""
+
+#: src/scastd.cpp
+msgid "Unknown DatabaseType. Falling back to mariadb\\n"
+msgstr ""


### PR DESCRIPTION
## Summary
- update translation templates to fall back to MariaDB when database type is unknown
- rebuild message catalogs

## Testing
- `msgfmt po/en.po -o /tmp/en.mo`
- `msgfmt po/scastd.pot -o /tmp/scastd.mo`


------
https://chatgpt.com/codex/tasks/task_e_68a27157c91c832b9c1e3a360a0f4e49