### PR TITLE
Rename MySQL test schema to MariaDB

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) @mariadb_CFLAGS@ -DTEST_SRCDIR=\"$(top_srcdir)\"
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) @mariadb_CFLAGS@ -DTEST_SRCDIR=\"$(top_srcdir)/tests\"
 
 check_PROGRAMS = unit_tests
 unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_icecast_dev.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp test_logger.cpp test_scastd_cli.cpp \
@@ -9,3 +9,4 @@ unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp te
 unit_tests_LDADD = $(DEPS_LIBS) $(LIBINTL) @mariadb_LIBS@
 
 TESTS = unit_tests
+EXTRA_DIST = src/mariadb.sql src/postgres.sql

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -568,7 +568,7 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) @mariadb_CFLAGS@ -DTEST_SRCDIR=\"$(top_srcdir)\"
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/tests $(DEPS_CFLAGS) @mariadb_CFLAGS@ -DTEST_SRCDIR=\"$(top_srcdir)/tests\"
 unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp test_icecast.cpp test_icecast_dev.cpp test_url_parser.cpp test_db_invalid.cpp test_setupdb.cpp test_missing_config.cpp test_pid.cpp test_logger.cpp test_scastd_cli.cpp \
     ../src/Config.cpp ../src/HttpServer.cpp ../src/icecast2.cpp ../src/UrlParser.cpp \
     ../src/CurlClient.cpp ../src/logger.cpp ../src/StatusLogger.cpp ../src/scastd.cpp \
@@ -576,6 +576,7 @@ unit_tests_SOURCES = test_main.cpp test_config.cpp test_sql.cpp test_http.cpp te
     ../src/db/PostgresDatabase.cpp stubs.cpp
 
 unit_tests_LDADD = $(DEPS_LIBS) $(LIBINTL) @mariadb_LIBS@
+EXTRA_DIST = src/mariadb.sql src/postgres.sql
 all: all-am
 
 .SUFFIXES:

--- a/tests/src/mariadb.sql
+++ b/tests/src/mariadb.sql
@@ -1,0 +1,111 @@
+# MariaDB schema for scastd
+# Host: localhost    Database: scastd
+#--------------------------------------------------------
+# Server version        10.x
+
+
+#
+# Table structure for table 'scastd_memberinfo'
+#
+
+DROP TABLE IF EXISTS scastd_memberinfo;
+CREATE TABLE scastd_memberinfo (
+  serverURL varchar(255) DEFAULT '0' NOT NULL,
+  password varchar(155) DEFAULT '' NOT NULL,
+  gather_flag varchar(155) DEFAULT '' NOT NULL,
+  PRIMARY KEY (serverURL)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+#
+# Dumping data for table 'scastd_memberinfo'
+#
+
+INSERT INTO scastd_memberinfo VALUES ('http://boa.mediacast1.com:9908','party7324','1');
+
+#
+# Table structure for table 'scastd_runtime'
+#
+
+DROP TABLE IF EXISTS scastd_runtime;
+CREATE TABLE scastd_runtime (
+  sleeptime INT DEFAULT NULL,
+  logfile VARCHAR(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+#
+# Dumping data for table 'scastd_runtime'
+#
+
+INSERT INTO scastd_runtime VALUES (30,'./scastd.log');
+
+#
+# Table structure for table 'scastd_serverinfo'
+#
+
+DROP TABLE IF EXISTS scastd_serverinfo;
+CREATE TABLE scastd_serverinfo (
+  serverURL VARCHAR(255) DEFAULT NULL,
+  currentlisteners INT DEFAULT NULL,
+  peaklisteners INT DEFAULT NULL,
+  maxlisteners INT DEFAULT NULL,
+  averagetime INT DEFAULT NULL,
+  streamhits INT DEFAULT NULL,
+  time TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+#
+# Dumping data for table 'scastd_serverinfo'
+#
+
+
+#
+# Table structure for table 'scastd_songinfo'
+#
+
+DROP TABLE IF EXISTS scastd_songinfo;
+CREATE TABLE scastd_songinfo (
+  serverURL VARCHAR(255) DEFAULT NULL,
+  songTitle VARCHAR(255) DEFAULT NULL,
+  time TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+#
+# Dumping data for table 'scastd_songinfo'
+#
+
+
+#
+# Table structure for table 'scastd_xml'
+#
+
+DROP TABLE IF EXISTS scastd_xml;
+CREATE TABLE scastd_xml (
+  id INT NOT NULL AUTO_INCREMENT,
+  currentlisteners VARCHAR(155) DEFAULT '' NOT NULL,
+  peaklisteners VARCHAR(155) DEFAULT '' NOT NULL,
+  maxlisteners VARCHAR(155) DEFAULT '' NOT NULL,
+  reportedlisteners VARCHAR(155) DEFAULT '' NOT NULL,
+  averagetime VARCHAR(255) DEFAULT '' NOT NULL,
+  servergenre VARCHAR(155) DEFAULT '' NOT NULL,
+  serverurl VARCHAR(255) DEFAULT '' NOT NULL,
+  servertitle VARCHAR(255) DEFAULT '' NOT NULL,
+  currentsong VARCHAR(255) DEFAULT '' NOT NULL,
+  webhits VARCHAR(155) DEFAULT '' NOT NULL,
+  streamhits VARCHAR(255) DEFAULT '' NOT NULL,
+  hostname VARCHAR(255) DEFAULT '' NOT NULL,
+  useragent VARCHAR(255) DEFAULT '' NOT NULL,
+  connecttime VARCHAR(155) DEFAULT '' NOT NULL,
+  songtitle VARCHAR(255) DEFAULT '' NOT NULL,
+  playedat VARCHAR(55) DEFAULT '' NOT NULL,
+  bwidthus VARCHAR(55) DEFAULT '' NOT NULL,
+  totbwidthus VARCHAR(255) DEFAULT '' NOT NULL,
+  date DATE DEFAULT '1970-01-01' NOT NULL,
+  time TIME DEFAULT '00:00:00' NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+#
+# Dumping data for table 'scastd_xml'
+#
+
+

--- a/tests/src/postgres.sql
+++ b/tests/src/postgres.sql
@@ -1,0 +1,69 @@
+-- PostgreSQL schema for scastd
+
+-- Table structure for table 'scastd_memberinfo'
+DROP TABLE IF EXISTS scastd_memberinfo;
+CREATE TABLE scastd_memberinfo (
+  serverURL TEXT PRIMARY KEY,
+  password TEXT NOT NULL DEFAULT '',
+  gather_flag TEXT NOT NULL DEFAULT ''
+);
+
+-- Dumping data for table 'scastd_memberinfo'
+INSERT INTO scastd_memberinfo (serverURL, password, gather_flag) VALUES
+  ('http://boa.mediacast1.com:9908', 'party7324', '1');
+
+-- Table structure for table 'scastd_runtime'
+DROP TABLE IF EXISTS scastd_runtime;
+CREATE TABLE scastd_runtime (
+  sleeptime INTEGER,
+  logfile TEXT
+);
+
+-- Dumping data for table 'scastd_runtime'
+INSERT INTO scastd_runtime (sleeptime, logfile) VALUES (30, './scastd.log');
+
+-- Table structure for table 'scastd_serverinfo'
+DROP TABLE IF EXISTS scastd_serverinfo;
+CREATE TABLE scastd_serverinfo (
+  serverURL TEXT,
+  currentlisteners INTEGER,
+  peaklisteners INTEGER,
+  maxlisteners INTEGER,
+  averagetime INTEGER,
+  streamhits INTEGER,
+  time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table structure for table 'scastd_songinfo'
+DROP TABLE IF EXISTS scastd_songinfo;
+CREATE TABLE scastd_songinfo (
+  serverURL TEXT,
+  songTitle TEXT,
+  time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table structure for table 'scastd_xml'
+DROP TABLE IF EXISTS scastd_xml;
+CREATE TABLE scastd_xml (
+  id SERIAL PRIMARY KEY,
+  currentlisteners TEXT NOT NULL DEFAULT '',
+  peaklisteners TEXT NOT NULL DEFAULT '',
+  maxlisteners TEXT NOT NULL DEFAULT '',
+  reportedlisteners TEXT NOT NULL DEFAULT '',
+  averagetime TEXT NOT NULL DEFAULT '',
+  servergenre TEXT NOT NULL DEFAULT '',
+  serverurl TEXT NOT NULL DEFAULT '',
+  servertitle TEXT NOT NULL DEFAULT '',
+  currentsong TEXT NOT NULL DEFAULT '',
+  webhits TEXT NOT NULL DEFAULT '',
+  streamhits TEXT NOT NULL DEFAULT '',
+  hostname TEXT NOT NULL DEFAULT '',
+  useragent TEXT NOT NULL DEFAULT '',
+  connecttime TEXT NOT NULL DEFAULT '',
+  songtitle TEXT NOT NULL DEFAULT '',
+  playedat TEXT NOT NULL DEFAULT '',
+  bwidthus TEXT NOT NULL DEFAULT '',
+  totbwidthus TEXT NOT NULL DEFAULT '',
+  date DATE NOT NULL DEFAULT CURRENT_DATE,
+  time TIME NOT NULL DEFAULT CURRENT_TIME
+);

--- a/tests/test_sql.cpp
+++ b/tests/test_sql.cpp
@@ -32,7 +32,8 @@ static std::string read_file(const std::string &path) {
 }
 
 TEST_CASE("MariaDB schema has required tables") {
-    std::string sql = read_file(std::string(TEST_SRCDIR) + "/src/mariadb.sql");
+    const std::string schema = std::string(TEST_SRCDIR) + "/src/mariadb.sql";
+    std::string sql = read_file(schema);
     REQUIRE(sql.find("CREATE TABLE scastd_memberinfo") != std::string::npos);
     REQUIRE(sql.find("CREATE TABLE scastd_runtime") != std::string::npos);
 }


### PR DESCRIPTION
## Summary
- add MariaDB test schema and include it in build scripts
- adjust unit tests to load the MariaDB schema
- distribute PostgreSQL schema alongside for tests

## Testing
- `./scripts/install_deps.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a278b722d8832ba50feae2c23cdce2