### PR TITLE
docs: replace MySQL references

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ We implement robust environment variable support for sensitive data and containe
 # Environment variables we recognize for secure configuration
 export SCASTD_USERNAME="statistics_user"
 export SCASTD_PASSWORD_FILE="/run/secrets/db_password"
-export SCASTD_DATABASE_HOST="mariadb-cluster.internal"
+export SCASTD_MARIADB_HOST="mariadb-cluster.internal"
 export SCASTD_API_TOKEN_SECRET="your-jwt-secret-here"
 export ICEADMINUSER="admin"
 export ICEUSERPASS="hackme"


### PR DESCRIPTION
## Summary
- replace `SCASTD_DATABASE_HOST` env var with `SCASTD_MARIADB_HOST`
- ensure docs highlight MariaDB badge and no MySQL badge

## Testing
- `make check`
- `rg -i mysql`


------
https://chatgpt.com/codex/tasks/task_e_68a278c7ba68832b81b918d67c80c494