### PR TITLE
Refactor server polling to use Icecast2

### DIFF
--- a/src/mariadb.sql
+++ b/src/mariadb.sql
@@ -5,22 +5,23 @@
 
 
 #
-# Table structure for table 'scastd_memberinfo'
+# Table structure for table 'servers'
 #
 
-DROP TABLE IF EXISTS scastd_memberinfo;
-CREATE TABLE scastd_memberinfo (
-  serverURL varchar(255) DEFAULT '0' NOT NULL,
-  password varchar(155) DEFAULT '' NOT NULL,
-  gather_flag varchar(155) DEFAULT '' NOT NULL,
-  PRIMARY KEY (serverURL)
+DROP TABLE IF EXISTS servers;
+CREATE TABLE servers (
+  server_host varchar(255) NOT NULL,
+  server_port int NOT NULL,
+  server_username varchar(255) DEFAULT '' NOT NULL,
+  server_password varchar(255) DEFAULT '' NOT NULL,
+  PRIMARY KEY (server_host, server_port)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 #
-# Dumping data for table 'scastd_memberinfo'
+# Dumping data for table 'servers'
 #
 
-INSERT INTO scastd_memberinfo VALUES ('http://boa.mediacast1.com:9908','party7324','1');
+INSERT INTO servers VALUES ('example.com', 8000, '', '');
 
 #
 # Table structure for table 'scastd_runtime'

--- a/src/postgres.sql
+++ b/src/postgres.sql
@@ -1,16 +1,18 @@
 -- PostgreSQL schema for scastd
 
--- Table structure for table 'scastd_memberinfo'
-DROP TABLE IF EXISTS scastd_memberinfo;
-CREATE TABLE scastd_memberinfo (
-  serverURL TEXT PRIMARY KEY,
-  password TEXT NOT NULL DEFAULT '',
-  gather_flag TEXT NOT NULL DEFAULT ''
+-- Table structure for table 'servers'
+DROP TABLE IF EXISTS servers;
+CREATE TABLE servers (
+  server_host TEXT NOT NULL,
+  server_port INTEGER NOT NULL,
+  server_username TEXT NOT NULL DEFAULT '',
+  server_password TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (server_host, server_port)
 );
 
--- Dumping data for table 'scastd_memberinfo'
-INSERT INTO scastd_memberinfo (serverURL, password, gather_flag) VALUES
-  ('http://boa.mediacast1.com:9908', 'party7324', '1');
+-- Dumping data for table 'servers'
+INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES
+  ('example.com', 8000, '', '');
 
 -- Table structure for table 'scastd_runtime'
 DROP TABLE IF EXISTS scastd_runtime;

--- a/src/sqlite.sql
+++ b/src/sqlite.sql
@@ -1,16 +1,18 @@
 -- SQLite schema for scastd
 
--- Table structure for table 'scastd_memberinfo'
-DROP TABLE IF EXISTS scastd_memberinfo;
-CREATE TABLE scastd_memberinfo (
-  serverURL TEXT PRIMARY KEY,
-  password TEXT NOT NULL DEFAULT '',
-  gather_flag TEXT NOT NULL DEFAULT ''
+-- Table structure for table 'servers'
+DROP TABLE IF EXISTS servers;
+CREATE TABLE servers (
+  server_host TEXT NOT NULL,
+  server_port INTEGER NOT NULL,
+  server_username TEXT NOT NULL DEFAULT '',
+  server_password TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (server_host, server_port)
 );
 
--- Dumping data for table 'scastd_memberinfo'
-INSERT INTO scastd_memberinfo (serverURL, password, gather_flag) VALUES
-  ('http://boa.mediacast1.com:9908', 'party7324', '1');
+-- Dumping data for table 'servers'
+INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES
+  ('example.com', 8000, '', '');
 
 -- Table structure for table 'scastd_runtime'
 DROP TABLE IF EXISTS scastd_runtime;

--- a/tests/src/mariadb.sql
+++ b/tests/src/mariadb.sql
@@ -5,22 +5,23 @@
 
 
 #
-# Table structure for table 'scastd_memberinfo'
+# Table structure for table 'servers'
 #
 
-DROP TABLE IF EXISTS scastd_memberinfo;
-CREATE TABLE scastd_memberinfo (
-  serverURL varchar(255) DEFAULT '0' NOT NULL,
-  password varchar(155) DEFAULT '' NOT NULL,
-  gather_flag varchar(155) DEFAULT '' NOT NULL,
-  PRIMARY KEY (serverURL)
+DROP TABLE IF EXISTS servers;
+CREATE TABLE servers (
+  server_host varchar(255) NOT NULL,
+  server_port int NOT NULL,
+  server_username varchar(255) DEFAULT '' NOT NULL,
+  server_password varchar(255) DEFAULT '' NOT NULL,
+  PRIMARY KEY (server_host, server_port)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 #
-# Dumping data for table 'scastd_memberinfo'
+# Dumping data for table 'servers'
 #
 
-INSERT INTO scastd_memberinfo VALUES ('http://boa.mediacast1.com:9908','party7324','1');
+INSERT INTO servers VALUES ('example.com', 8000, '', '');
 
 #
 # Table structure for table 'scastd_runtime'

--- a/tests/src/postgres.sql
+++ b/tests/src/postgres.sql
@@ -1,16 +1,18 @@
 -- PostgreSQL schema for scastd
 
--- Table structure for table 'scastd_memberinfo'
-DROP TABLE IF EXISTS scastd_memberinfo;
-CREATE TABLE scastd_memberinfo (
-  serverURL TEXT PRIMARY KEY,
-  password TEXT NOT NULL DEFAULT '',
-  gather_flag TEXT NOT NULL DEFAULT ''
+-- Table structure for table 'servers'
+DROP TABLE IF EXISTS servers;
+CREATE TABLE servers (
+  server_host TEXT NOT NULL,
+  server_port INTEGER NOT NULL,
+  server_username TEXT NOT NULL DEFAULT '',
+  server_password TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (server_host, server_port)
 );
 
--- Dumping data for table 'scastd_memberinfo'
-INSERT INTO scastd_memberinfo (serverURL, password, gather_flag) VALUES
-  ('http://boa.mediacast1.com:9908', 'party7324', '1');
+-- Dumping data for table 'servers'
+INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES
+  ('example.com', 8000, '', '');
 
 -- Table structure for table 'scastd_runtime'
 DROP TABLE IF EXISTS scastd_runtime;

--- a/tests/test_setupdb.cpp
+++ b/tests/test_setupdb.cpp
@@ -33,7 +33,7 @@ TEST_CASE("setupdb flag initializes SQLite database") {
     sqlite3 *db = nullptr;
     REQUIRE(sqlite3_open(tmp.string().c_str(), &db) == SQLITE_OK);
     sqlite3_stmt *stmt = nullptr;
-    REQUIRE(sqlite3_prepare_v2(db, "SELECT name FROM sqlite_master WHERE type='table' AND name='scastd_memberinfo';", -1, &stmt, nullptr) == SQLITE_OK);
+    REQUIRE(sqlite3_prepare_v2(db, "SELECT name FROM sqlite_master WHERE type='table' AND name='servers';", -1, &stmt, nullptr) == SQLITE_OK);
     REQUIRE(sqlite3_step(stmt) == SQLITE_ROW);
     sqlite3_finalize(stmt);
     sqlite3_close(db);

--- a/tests/test_sql.cpp
+++ b/tests/test_sql.cpp
@@ -34,12 +34,12 @@ static std::string read_file(const std::string &path) {
 TEST_CASE("MariaDB schema has required tables") {
     const std::string schema = std::string(TEST_SRCDIR) + "/src/mariadb.sql";
     std::string sql = read_file(schema);
-    REQUIRE(sql.find("CREATE TABLE scastd_memberinfo") != std::string::npos);
+    REQUIRE(sql.find("CREATE TABLE servers") != std::string::npos);
     REQUIRE(sql.find("CREATE TABLE scastd_runtime") != std::string::npos);
 }
 
 TEST_CASE("PostgreSQL schema has required tables") {
     std::string sql = read_file(std::string(TEST_SRCDIR) + "/src/postgres.sql");
-    REQUIRE(sql.find("CREATE TABLE scastd_memberinfo") != std::string::npos);
+    REQUIRE(sql.find("CREATE TABLE servers") != std::string::npos);
     REQUIRE(sql.find("CREATE TABLE scastd_runtime") != std::string::npos);
 }


### PR DESCRIPTION
## Summary
- Replace member info lookup with `servers` table query
- Poll Icecast2 stats per host/port and record results in server and song tables
- Update SQL schema and tests to remove `scastd_memberinfo`

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `./configure` *(fails: cannot find required auxiliary files)*
- `./autogen.sh` *(fails: 'aclocal' not found. Please install automake)*

------
https://chatgpt.com/codex/tasks/task_e_68a2898beb34832bb06e3a59c3df7cfc