### PR TITLE
Refactor DB schema to new servers table

### DIFF
--- a/src/mariadb.sql
+++ b/src/mariadb.sql
@@ -5,23 +5,28 @@
 
 
 #
+# Remove legacy member table
+#
+DROP TABLE IF EXISTS scastd_memberinfo;
+
+#
 # Table structure for table 'servers'
 #
 
 DROP TABLE IF EXISTS servers;
 CREATE TABLE servers (
-  server_host varchar(255) NOT NULL,
-  server_port int NOT NULL,
-  server_username varchar(255) DEFAULT '' NOT NULL,
-  server_password varchar(255) DEFAULT '' NOT NULL,
-  PRIMARY KEY (server_host, server_port)
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  server_host VARCHAR(255) NOT NULL,
+  server_port BIGINT NOT NULL,
+  server_username VARCHAR(255),
+  server_password VARCHAR(255)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 #
 # Dumping data for table 'servers'
 #
 
-INSERT INTO servers VALUES ('example.com', 8000, '', '');
+INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES ('example.com', 8000, NULL, NULL);
 
 #
 # Table structure for table 'scastd_runtime'

--- a/src/postgres.sql
+++ b/src/postgres.sql
@@ -1,18 +1,21 @@
 -- PostgreSQL schema for scastd
 
+-- Remove legacy member table
+DROP TABLE IF EXISTS scastd_memberinfo;
+
 -- Table structure for table 'servers'
 DROP TABLE IF EXISTS servers;
 CREATE TABLE servers (
+  id SERIAL PRIMARY KEY,
   server_host TEXT NOT NULL,
-  server_port INTEGER NOT NULL,
-  server_username TEXT NOT NULL DEFAULT '',
-  server_password TEXT NOT NULL DEFAULT '',
-  PRIMARY KEY (server_host, server_port)
+  server_port BIGINT NOT NULL,
+  server_username TEXT,
+  server_password TEXT
 );
 
 -- Dumping data for table 'servers'
 INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES
-  ('example.com', 8000, '', '');
+  ('example.com', 8000, NULL, NULL);
 
 -- Table structure for table 'scastd_runtime'
 DROP TABLE IF EXISTS scastd_runtime;

--- a/src/sqlite.sql
+++ b/src/sqlite.sql
@@ -1,18 +1,21 @@
 -- SQLite schema for scastd
 
+-- Remove legacy member table
+DROP TABLE IF EXISTS scastd_memberinfo;
+
 -- Table structure for table 'servers'
 DROP TABLE IF EXISTS servers;
 CREATE TABLE servers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
   server_host TEXT NOT NULL,
   server_port INTEGER NOT NULL,
-  server_username TEXT NOT NULL DEFAULT '',
-  server_password TEXT NOT NULL DEFAULT '',
-  PRIMARY KEY (server_host, server_port)
+  server_username TEXT,
+  server_password TEXT
 );
 
 -- Dumping data for table 'servers'
 INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES
-  ('example.com', 8000, '', '');
+  ('example.com', 8000, NULL, NULL);
 
 -- Table structure for table 'scastd_runtime'
 DROP TABLE IF EXISTS scastd_runtime;

--- a/tests/src/mariadb.sql
+++ b/tests/src/mariadb.sql
@@ -5,23 +5,28 @@
 
 
 #
+# Remove legacy member table
+#
+DROP TABLE IF EXISTS scastd_memberinfo;
+
+#
 # Table structure for table 'servers'
 #
 
 DROP TABLE IF EXISTS servers;
 CREATE TABLE servers (
-  server_host varchar(255) NOT NULL,
-  server_port int NOT NULL,
-  server_username varchar(255) DEFAULT '' NOT NULL,
-  server_password varchar(255) DEFAULT '' NOT NULL,
-  PRIMARY KEY (server_host, server_port)
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  server_host VARCHAR(255) NOT NULL,
+  server_port BIGINT NOT NULL,
+  server_username VARCHAR(255),
+  server_password VARCHAR(255)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 #
 # Dumping data for table 'servers'
 #
 
-INSERT INTO servers VALUES ('example.com', 8000, '', '');
+INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES ('example.com', 8000, NULL, NULL);
 
 #
 # Table structure for table 'scastd_runtime'

--- a/tests/src/postgres.sql
+++ b/tests/src/postgres.sql
@@ -1,18 +1,21 @@
 -- PostgreSQL schema for scastd
 
+-- Remove legacy member table
+DROP TABLE IF EXISTS scastd_memberinfo;
+
 -- Table structure for table 'servers'
 DROP TABLE IF EXISTS servers;
 CREATE TABLE servers (
+  id SERIAL PRIMARY KEY,
   server_host TEXT NOT NULL,
-  server_port INTEGER NOT NULL,
-  server_username TEXT NOT NULL DEFAULT '',
-  server_password TEXT NOT NULL DEFAULT '',
-  PRIMARY KEY (server_host, server_port)
+  server_port BIGINT NOT NULL,
+  server_username TEXT,
+  server_password TEXT
 );
 
 -- Dumping data for table 'servers'
 INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES
-  ('example.com', 8000, '', '');
+  ('example.com', 8000, NULL, NULL);
 
 -- Table structure for table 'scastd_runtime'
 DROP TABLE IF EXISTS scastd_runtime;

--- a/tests/test_setupdb.cpp
+++ b/tests/test_setupdb.cpp
@@ -35,6 +35,10 @@ TEST_CASE("setupdb flag initializes SQLite database") {
     sqlite3_stmt *stmt = nullptr;
     REQUIRE(sqlite3_prepare_v2(db, "SELECT name FROM sqlite_master WHERE type='table' AND name='servers';", -1, &stmt, nullptr) == SQLITE_OK);
     REQUIRE(sqlite3_step(stmt) == SQLITE_ROW);
+    REQUIRE(std::string(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0))) == "servers");
+    sqlite3_finalize(stmt);
+    REQUIRE(sqlite3_prepare_v2(db, "SELECT name FROM sqlite_master WHERE type='table' AND name='scastd_memberinfo';", -1, &stmt, nullptr) == SQLITE_OK);
+    REQUIRE(sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);
     sqlite3_close(db);
     std::filesystem::remove(tmp);

--- a/tests/test_sql.cpp
+++ b/tests/test_sql.cpp
@@ -34,12 +34,14 @@ static std::string read_file(const std::string &path) {
 TEST_CASE("MariaDB schema has required tables") {
     const std::string schema = std::string(TEST_SRCDIR) + "/src/mariadb.sql";
     std::string sql = read_file(schema);
+    REQUIRE(sql.find("DROP TABLE IF EXISTS scastd_memberinfo") != std::string::npos);
     REQUIRE(sql.find("CREATE TABLE servers") != std::string::npos);
     REQUIRE(sql.find("CREATE TABLE scastd_runtime") != std::string::npos);
 }
 
 TEST_CASE("PostgreSQL schema has required tables") {
     std::string sql = read_file(std::string(TEST_SRCDIR) + "/src/postgres.sql");
+    REQUIRE(sql.find("DROP TABLE IF EXISTS scastd_memberinfo") != std::string::npos);
     REQUIRE(sql.find("CREATE TABLE servers") != std::string::npos);
     REQUIRE(sql.find("CREATE TABLE scastd_runtime") != std::string::npos);
 }


### PR DESCRIPTION
## Summary
- Replace legacy `scastd_memberinfo` with a new `servers` table in MariaDB, PostgreSQL and SQLite schemas
- Mirror updated schema in test fixtures
- Extend SQL tests to verify the new table and removal of `scastd_memberinfo`

## Testing
- `make check TESTS="test_sql test_setupdb"` *(fails: PostgresDatabase.cpp compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a28cb41144832bb4c67190a77c4392