### PR TITLE
ci: expose secrets for integration tests

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -90,6 +90,13 @@ runs:
       shell: bash
       run: |
         set -o pipefail
+        export MARIADB_TEST_HOST="${MARIADB_TEST_HOST}"
+        export MARIADB_TEST_USER="${MARIADB_TEST_USER}"
+        export MARIADB_TEST_PASS="${MARIADB_TEST_PASS}"
+        export ICECAST_DEV_HOST="${ICECAST_DEV_HOST}"
+        export ICECAST_DEV_PORT="${ICECAST_DEV_PORT}"
+        export ICEADMINUSER="${ICEADMINUSER}"
+        export ICEUSERPASS="${ICEUSERPASS}"
         make check 2>&1 | tee test.log
     - name: Verify scastd --help
       shell: bash

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -35,6 +35,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-and-test
+        env:
+          MARIADB_TEST_HOST: ${{ secrets.MARIADB_TEST_HOST }}
+          MARIADB_TEST_USER: ${{ secrets.MARIADB_TEST_USER }}
+          MARIADB_TEST_PASS: ${{ secrets.MARIADB_TEST_PASS }}
+          ICECAST_DEV_HOST: ${{ secrets.ICECAST_DEV_HOST }}
+          ICECAST_DEV_PORT: ${{ secrets.ICECAST_DEV_PORT }}
+          ICEADMINUSER: ${{ secrets.ICEADMINUSER }}
+          ICEUSERPASS: ${{ secrets.ICEUSERPASS }}
         with:
           distro: ${{ matrix.distro }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  MARIADB_TEST_HOST: ${{ secrets.MARIADB_TEST_HOST }}
+  MARIADB_TEST_USER: ${{ secrets.MARIADB_TEST_USER }}
+  MARIADB_TEST_PASS: ${{ secrets.MARIADB_TEST_PASS }}
+  ICECAST_DEV_HOST: ${{ secrets.ICECAST_DEV_HOST }}
+  ICECAST_DEV_PORT: ${{ secrets.ICECAST_DEV_PORT }}
+  ICEADMINUSER: ${{ secrets.ICEADMINUSER }}
+  ICEUSERPASS: ${{ secrets.ICEUSERPASS }}
 
 jobs:
   # Extract version from tag for use across jobs

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ macOS users can run:
 shasum -a 256 -c CHECKSUMS.txt
 ```
 
+## 🧪 Required Secrets for CI and Local Testing
+
+| Secret | Purpose |
+| ------ | ------- |
+| `MARIADB_TEST_HOST` | Hostname of the MariaDB instance used for tests |
+| `MARIADB_TEST_USER` | User for the test MariaDB database |
+| `MARIADB_TEST_PASS` | Password for the test MariaDB user |
+| `ICECAST_DEV_HOST` | Hostname of the development Icecast server |
+| `ICECAST_DEV_PORT` | Port of the development Icecast server |
+| `ICEADMINUSER` | Icecast administrator username used in tests |
+| `ICEUSERPASS` | Icecast user password used in tests |
+
 ---
 
 ## 🎯 What is SCASTD?


### PR DESCRIPTION
## Summary
- export database and Icecast credentials in build-and-test action before running tests
- pass secret variables to build-and-test action in dev and release workflows
- document CI secret requirements for database and Icecast tests

## Testing
- `./autogen.sh` *(fails: 'aclocal' not found)*
- `./configure` *(fails: cannot find required auxiliary files)*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68a2adecbca4832b9481c64fa49b8885