### PR TITLE
docs: document MariaDB and Icecast setup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,6 +63,27 @@ Configuration file locations
 * `/usr/local/etc/scastd/scastd.conf` (macOS Intel)
 * `/opt/homebrew/etc/scastd/scastd.conf` (macOS Apple Silicon)
 
+Initialize the `servers` table
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Create the database schema and add an Icecast server:
+
+```bash
+scastd --setupdb mariadb
+mysql -u scastd -p scastd -e "INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES ('stream.example.com', 8000, 'admin', 'hackme');"
+```
+
+Credentials via environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sensitive credentials can be provided through environment variables:
+
+```bash
+export SCASTD_MARIADB_HOST=localhost
+export SCASTD_USERNAME=scastd
+export SCASTD_PASSWORD=changeme
+export ICEADMINUSER=admin
+export ICEUSERPASS=hackme
+```
+
 Service management
 ~~~~~~~~~~~~~~~~~~
 * Debian/Ubuntu:
@@ -145,9 +166,8 @@ TLS certificates
 
 ```bash
 sudo certbot certonly --standalone -d example.com
-# Certificates:
-#   /etc/letsencrypt/live/example.com/fullchain.pem
-#   /etc/letsencrypt/live/example.com/privkey.pem
+sudo ls /etc/letsencrypt/live/example.com/
+# fullchain.pem  privkey.pem
 ```
 
 Reference them in `/etc/scastd/scastd.conf`:
@@ -169,9 +189,10 @@ scastd --ssl-enable \
 ```bash
 brew install certbot
 sudo certbot certonly --standalone -d example.com
-# Certificates:
-#   /usr/local/etc/letsencrypt/live/example.com/... (Intel)
-#   /opt/homebrew/etc/letsencrypt/live/example.com/... (Apple Silicon)
+sudo ls /usr/local/etc/letsencrypt/live/example.com/   # Intel
+# fullchain.pem  privkey.pem
+sudo ls /opt/homebrew/etc/letsencrypt/live/example.com/  # Apple Silicon
+# fullchain.pem  privkey.pem
 ```
 
 Reference in `scastd.conf` under the Homebrew prefix:

--- a/README.md
+++ b/README.md
@@ -476,6 +476,32 @@ These credentials configure access to the Icecast administrative interface. If
 `ICEADMINUSER` or `ICEUSERPASS` are not provided, the daemon falls back to the
 legacy `SCASTD_ADMINUSER` and `SCASTD_USERPASS` variables.
 
+### MariaDB Setup
+
+Install MariaDB and create a database for SCASTD:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y mariadb-server mariadb-client
+sudo mysql -e "CREATE DATABASE scastd; GRANT ALL ON scastd.* TO 'scastd'@'localhost' IDENTIFIED BY 'changeme';"
+```
+
+Add an Icecast server to the `servers` table:
+
+```bash
+mysql -u scastd -p scastd -e "INSERT INTO servers (server_host, server_port, server_username, server_password) VALUES ('stream.example.com', 8000, 'admin', 'hackme');"
+```
+
+Reference the MariaDB instance in `scastd.conf`:
+
+```conf
+db_type    mariadb
+db_host    localhost
+db_name    scastd
+db_user    scastd
+db_pass    changeme
+```
+
 For detailed configuration instructions, please refer to our comprehensive [Installation Guide](INSTALL.md).
 
 ---

--- a/docs/Icecast2.md
+++ b/docs/Icecast2.md
@@ -5,6 +5,27 @@ HTTP and exposes key fields such as listener counts, bitrates and the currently
 playing track. It authenticates with the Icecast administrative interface using
 HTTP Basic authentication and parses the returned `stats.xml` document.
 
+## Servers Table
+
+SCASTD stores Icecast endpoints in the `servers` table:
+
+| Column | Type | Description |
+| ------ | ---- | ----------- |
+| `id` | INT | Primary key |
+| `server_host` | VARCHAR(255) | Hostname |
+| `server_port` | BIGINT | Port number |
+| `server_username` | VARCHAR(255) | Optional admin user |
+| `server_password` | VARCHAR(255) | Optional admin password |
+
+Insert the provided development server:
+
+```sql
+INSERT INTO servers (server_host, server_port, server_username, server_password)
+VALUES ('$ICECAST_DEV_HOST', $ICECAST_DEV_PORT, '$ICEADMINUSER', '$ICEUSERPASS');
+```
+
+See [`src/mariadb.sql`](../src/mariadb.sql) for the full schema.
+
 ## Example
 
 ```cpp
@@ -44,3 +65,35 @@ new names are not set:
 
 These values are used when establishing the HTTP connection to
 `/admin/stats.xml`.
+
+## Full Example Using Provided Server
+
+The following program queries the Icecast2 server defined in the `servers`
+table using credentials supplied via environment variables:
+
+```cpp
+#include "CurlClient.h"
+#include "icecast2.h"
+#include <cstdlib>
+#include <iostream>
+
+int main() {
+    CurlClient http;
+    const char* host = std::getenv("ICECAST_DEV_HOST");
+    int port = std::atoi(std::getenv("ICECAST_DEV_PORT"));
+    scastd::Icecast2 client(host, port,
+                            std::getenv("ICEADMINUSER"),
+                            std::getenv("ICEUSERPASS"),
+                            http);
+    std::vector<scastd::Icecast2::StreamInfo> stats;
+    std::string err;
+    if (client.fetchStats(stats, err)) {
+        for (const auto &s : stats) {
+            std::cout << s.mount << ": " << s.listeners << " listeners\n";
+        }
+    } else {
+        std::cerr << "Failed to fetch stats: " << err << std::endl;
+    }
+    return 0;
+}
+```


### PR DESCRIPTION
## Summary
- document MariaDB setup with sample `servers` entry and config snippet
- add install steps for initializing `servers` table, env credentials, and HTTPS via certbot
- expand Icecast2 guide with `servers` table schema and end-to-end example

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68a2b05f9370832ba695a054db087c67