### PR TITLE
Document servers table setup in scastd.conf

### DIFF
--- a/scastd.conf
+++ b/scastd.conf
@@ -8,12 +8,20 @@
 pid_file /var/run/scastd.pid
 username root
 password secret
+# Database type (mariadb, postgres, sqlite).
+# May be overridden on the command line with --db-type
 DatabaseType mariadb
 host localhost
 port 3306
 dbname scastd
 # Path to SQLite database file (used when DatabaseType is sqlite or credentials are missing)
 sqlite_path /etc/scastd/scastd.db
+# scastd expects a 'servers' table in the selected database with at least
+#   server_host VARCHAR(255), server_port INT,
+#   server_username VARCHAR(255), server_password VARCHAR(255)
+# Add servers to monitor by inserting rows, e.g.:
+# INSERT INTO servers (server_host, server_port, server_username, server_password)
+# VALUES ('test.icecast.org', 8000, 'admin', 'hackme');  # Icecast2 test server
 # sslmode disable
 
 # Resource limits


### PR DESCRIPTION
## Summary
- note that `DatabaseType` can be overridden with `--db-type`
- document the required `servers` table and how to populate it
- include sample SQL for inserting the Icecast2 test server

## Testing
- `make check` *(fails: db/PostgresDatabase.cpp: class 'PostgresDatabase' does not have any field named 'conn')*


------
https://chatgpt.com/codex/tasks/task_e_68a357c6440c832bb6f3c8b465be9b6d